### PR TITLE
Inexplicably fix OS X's make happy by removing spaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -403,7 +403,7 @@ finish: $(SYSROOT_INC) libc
 	for undef_sym in $$($(WASM_NM) --undefined-only "$(SYSROOT_LIB)"/*.a "$(SYSROOT_LIB)"/*.o \
 	    |grep ' U ' |sed 's/.* U //' |LC_COLLATE=C sort |uniq); do \
 	    grep -q '\<'$$undef_sym'\>' "$(SYSROOT_SHARE)/defined-symbols.txt" || echo $$undef_sym; \
-	done   > "$(SYSROOT_SHARE)/undefined-symbols.txt"
+	done > "$(SYSROOT_SHARE)/undefined-symbols.txt"
 	grep '^_*wasi_' "$(SYSROOT_SHARE)/undefined-symbols.txt" \
 	    > "$(SYSROOT_LIB)/libc.imports"
 


### PR DESCRIPTION
When attempting to `make package` on OS X, I was confronted with this error:
```
#
# Collect metadata on the sysroot and perform sanity checks.
#
mkdir -p "/opt/wasi-sdk/share/sysroot/share/wasm32-wasi"
# Collect symbol information.
# TODO: Use llvm-nm --extern-only instead of grep. This is blocked on
# LLVM PR40497, which is fixed in 9.0, but not in 8.0.
/opt/wasi-sdk/bin/llvm-nm --defined-only "/opt/wasi-sdk/share/sysroot/lib/wasm32-wasi"/libc.a "/opt/wasi-sdk/share/sysroot/lib/wasm32-wasi"/*.o \
        |grep ' [[:upper:]] ' |sed 's/.* [[:upper:]] //' |LC_COLLATE=C sort > "/opt/wasi-sdk/share/sysroot/share/wasm32-wasi/defined-symbols.txt"
for undef_sym in $(/opt/wasi-sdk/bin/llvm-nm --undefined-only "/opt/wasi-sdk/share/sysroot/lib/wasm32-wasi"/*.a "/opt/wasi-sdk/share/sysroot/lib/wasm32-wasi"/*.o |grep ' U ' |sed 's/.* U //' |LC_COLLATE=C sort |uniq); do \
        grep -q '\<'$undef_sym'\>' "/opt/wasi-sdk/share/sysroot/share/wasm32-wasi/defined-symbols.txt" || echo $undef_sym; \
    done   > "/opt/wasi-sdk/share/sysroot/share/wasm32-wasi/undefinols.txt"ls.txt"
/bin/sh: -c: line 0: unexpected EOF while looking for matching `"'
/bin/sh: -c: line 1: syntax error: unexpected end of file
make[1]: *** [finish] Error 2
make: *** [build/reference-sysroot.BUILT] Error 2
```

It appears that the `    done   > "/opt/wasi-sdk/share/sysroot/share/wasm32-wasi/undefinols.txt"ls.txt"` bit is getting corrupted. I tried several things to figure out what was going on. However, simply removing the extra spaces between `done` and `>` seems to have fixed it. I have no idea why. But the build reliably works now.