### PR TITLE
Use `patsubst` instead of `subst`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 # These variables are specifically meant to be overridable via
 # the make command-line.
 WASM_CC = clang
-WASM_NM = $(subst clang,llvm-nm,$(WASM_CC))
-WASM_AR = $(subst clang,llvm-ar,$(WASM_CC))
+WASM_NM = $(patsubst %clang,%llvm-nm,$(WASM_CC))
+WASM_AR = $(patsubst %clang,%llvm-ar,$(WASM_CC))
 WASM_CFLAGS = -O2
 # The directory where we build the sysroot.
 SYSROOT = $(CURDIR)/sysroot


### PR DESCRIPTION
This helps handling when `clang` shows up in not only the file name but
also directory name for where the `clang` executable is located. When
figuring out the path to `wasm-nm` and `wasm-ar` we want to replace just
the final component, not all `clang` words.