### PR TITLE
Don't leave intermediate build artifacts in the sysroot.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ BUILD_DLMALLOC = yes
 BUILD_LIBC_BOTTOM_HALF = yes
 BUILD_LIBC_TOP_HALF = yes
 # The directory where we're store intermediate artifacts.
-OBJDIR = $(SYSROOT)/tmp
+OBJDIR = $(CURDIR)/build
 
 # Check dependencies.
 ifeq ($(BUILD_LIBC_TOP_HALF),yes)


### PR DESCRIPTION
Previously we put .o files used in the build sitting in sysroot/tmp. This meant that they were getting included in the release package, even though they aren't needed. Moving them out shrinks the package from 9.2M to 2.1M.