### PR TITLE
Fix -std=gnu17 when generating predefined_macros.txt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -480,7 +480,7 @@ finish: startup_files libc
 	# TODO: Filter out __FLT16_* for now, as not all versions of clang have these.
 	"$(WASM_CC)" $(WASM_CFLAGS) "$(SYSROOT_SHARE)/include-all.c" \
 	    -isystem $(SYSROOT_INC) \
-	    -std=gnu11 \
+	    -std=gnu17 \
 	    -E -dM -Wno-\#warnings \
 	    -D_ALL_SOURCE \
 	    -U__llvm__ \

--- a/Makefile
+++ b/Makefile
@@ -480,6 +480,7 @@ finish: startup_files libc
 	# TODO: Filter out __FLT16_* for now, as not all versions of clang have these.
 	"$(WASM_CC)" $(WASM_CFLAGS) "$(SYSROOT_SHARE)/include-all.c" \
 	    -isystem $(SYSROOT_INC) \
+	    -std=gnu11 \
 	    -E -dM -Wno-\#warnings \
 	    -D_ALL_SOURCE \
 	    -U__llvm__ \

--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -2774,7 +2774,7 @@
 #define __STDC_ISO_10646__ 201206L
 #define __STDC_UTF_16__ 1
 #define __STDC_UTF_32__ 1
-#define __STDC_VERSION__ 201112L
+#define __STDC_VERSION__ 201710L
 #define __STDC__ 1
 #define __STDDEF_H 
 #define __UAPI_DEF_IN6_ADDR 0


### PR DESCRIPTION
The default recently changed in upstream clang:
https://reviews.llvm.org/D75383


We want to be immune to such things when generating this list so that
we can build wasi-libc with any recent clang version.