### PR TITLE
Fix references to musl version

### DIFF
--- a/libc-top-half/README.md
+++ b/libc-top-half/README.md
@@ -1,5 +1,5 @@
 Code in the musl directory is based on musl revision
-b07d45eb01e900f0176894fdedab62285f5cb8be, which is v1.1.23, from
+040c1d16b468c50c04fc94edff521f1637708328, which is v1.2.0, from
 git://git.musl-libc.org/musl.
 
 Whole files which are unused are omitted. Changes to upstream code are wrapped

--- a/libc-top-half/musl/README
+++ b/libc-top-half/musl/README
@@ -20,4 +20,4 @@ Information on full musl-targeted compiler toolchains, system
 bootstrapping, and Linux distributions built on musl can be found on
 the project website:
 
-    http://www.musl-libc.org/
+    http://musl.libc.org/

--- a/libc-top-half/musl/README
+++ b/libc-top-half/musl/README
@@ -20,4 +20,4 @@ Information on full musl-targeted compiler toolchains, system
 bootstrapping, and Linux distributions built on musl can be found on
 the project website:
 
-    http://musl.libc.org/
+    https://musl.libc.org/


### PR DESCRIPTION
Git revision needs double-checking!

N.B.: `libc-bottom-half` still seems to refer to an older `musl`.