### PR TITLE
Try to fix mac ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install clang (MacOS)
       shell: bash
       run: |
-        curl -sSf http://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-darwin-apple.tar.xz | tar xJf -
+        curl -sSfL https://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-darwin-apple.tar.xz | tar xJf -
         export CLANG_DIR=`pwd`/clang+llvm-9.0.0-x86_64-darwin-apple/bin
         echo "::add-path::$CLANG_DIR"
         echo "::set-env name=WASM_CC::$CLANG_DIR/clang"
@@ -43,7 +43,7 @@ jobs:
     - name: Install clang (Linux)
       shell: bash
       run: |
-        curl -sSf https://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz | tar xJf -
+        curl -sSfL https://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz | tar xJf -
         export CLANG_DIR=`pwd`/clang+llvm-9.0.0-x86_64-linux-gnu-ubuntu-16.04/bin
         echo "::add-path::$CLANG_DIR"
         echo "::set-env name=WASM_CC::$CLANG_DIR/clang"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,7 @@ jobs:
       shell: bash
       run: |
         curl -sSfL https://releases.llvm.org/9.0.0/clang+llvm-9.0.0-x86_64-darwin-apple.tar.xz | tar xJf -
+        ls clang+llvm-9.0.0-x86_64-darwin-apple
         export CLANG_DIR=`pwd`/clang+llvm-9.0.0-x86_64-darwin-apple/bin
         echo "::add-path::$CLANG_DIR"
         echo "::set-env name=WASM_CC::$CLANG_DIR/clang"


### PR DESCRIPTION
Installing clang was broken, for some reason (#193). I suspect that its because llvm's releases site now redirects the download to github?