### PR TITLE
Make mmap() possible to use in a conformant way

### DIFF
--- a/libc-bottom-half/mman/mman.c
+++ b/libc-bottom-half/mman/mman.c
@@ -23,9 +23,10 @@ struct map {
 void *mmap(void *addr, size_t length, int prot, int flags,
            int fd, off_t offset) {
     // Check for unsupported flags.
-    if ((flags & MAP_FIXED) != 0 ||
+    if ((flags & (MAP_PRIVATE | MAP_SHARED)) == 0 ||
+        (flags & MAP_FIXED) != 0 ||
 #ifdef MAP_SHARED_VALIDATE
-        (flags & MAP_SHARED_VALIDATE) != 0 ||
+        (flags & MAP_SHARED_VALIDATE) == MAP_SHARED_VALIDATE ||
 #endif
 #ifdef MAP_NORESERVE
         (flags & MAP_NORESERVE) != 0 ||


### PR DESCRIPTION
wasi-libc defines `MAP_SHARED_VALIDATE` as `MAP_SHARED|MAP_PRIVATE`: https://github.com/WebAssembly/wasi-libc/blob/86550c37ab14962233f73413ea0e0c0e57d056d7/libc-top-half/musl/include/sys/mman.h#L25-L27

POSIX [requires](https://pubs.opengroup.org/onlinepubs/9699919799/functions/mmap.html) either `MAP_SHARED` or `MAP_PRIVATE` to be specified: ![Screenshot_20200523_144435](https://user-images.githubusercontent.com/54771/82733531-ec1ce200-9d03-11ea-8b03-490178e48d1d.png)

Because `MAP_SHARED_VALIDATE` is not an unique bit flag, the current code makes it impossible to use `mmap()` in wasi-libc in a standards-conformant way.

For context, here's the rather sad [history](https://lwn.net/Articles/758594/) behind `MAP_SHARED_VALIDATE`.