### PR TITLE
Rename `__prepare_for_exit` to `__wasm_call_dtors`.

### DIFF
--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -172,7 +172,6 @@ __polevll
 __posix_getopt
 __pow_log_data
 __powf_log2_data
-__prepare_for_exit
 __progname
 __progname_full
 __putenv
@@ -263,6 +262,7 @@ __wasilibc_register_preopened_fd
 __wasilibc_rmdirat
 __wasilibc_tell
 __wasilibc_unlinkat
+__wasm_call_dtors
 __wcscoll_l
 __wcsftime_l
 __wcsxfrm_l

--- a/libc-bottom-half/crt/crt1.c
+++ b/libc-bottom-half/crt/crt1.c
@@ -1,7 +1,7 @@
 #include <wasi/api.h>
 extern void __wasm_call_ctors(void);
 extern int __original_main(void);
-extern void __prepare_for_exit(void);
+extern void __wasm_call_dtors(void);
 
 __attribute__((export_name("_start")))
 void _start(void) {
@@ -14,7 +14,7 @@ void _start(void) {
     int r = __original_main();
 
     // Call atexit functions, destructors, stdio cleanup, etc.
-    __prepare_for_exit();
+    __wasm_call_dtors();
 
     // If main exited successfully, just return, otherwise call
     // `__wasi_proc_exit`.

--- a/libc-top-half/musl/src/exit/exit.c
+++ b/libc-top-half/musl/src/exit/exit.c
@@ -38,7 +38,7 @@ _Noreturn void exit(int code)
 // Split out the cleanup functions so that we can call them without calling
 // _Exit if we don't need to. This allows _start to just return if main
 // returns 0.
-void __prepare_for_exit(void)
+void __wasm_call_dtors(void)
 {
 	__funcs_on_exit();
 	__stdio_exit();
@@ -46,7 +46,7 @@ void __prepare_for_exit(void)
 
 _Noreturn void exit(int code)
 {
-	__prepare_for_exit();
+	__wasm_call_dtors();
 	_Exit(code);
 }
 #endif


### PR DESCRIPTION
This emphasizes the relationship with `__wasm_call_ctors`. Note however
that while `__wasm_call_ctors` is synthesized by the linker,
`__wasm_call_dtors` is still defined by libc.

Static constructors are registered statically, but static destructors
need to be registered dynamically so that they only run if their
corresponding static constructors have run, and so that they're
ordered with respect to interleaved `atexit` calls.