### PR TITLE
New-style command support.

### DIFF
--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -276,6 +276,7 @@ _exit
 _flushlbf
 _initialize
 _start
+_start
 a64l
 abort
 abs

--- a/libc-bottom-half/cloudlibc/src/include/stdlib.h
+++ b/libc-bottom-half/cloudlibc/src/include/stdlib.h
@@ -139,8 +139,8 @@ void *calloc(size_t, size_t);
 div_t div(int, int) __pure2;
 double drand48(void);
 double erand48(__uint16_t *);
-_Noreturn void exit(int);
 #endif
+_Noreturn void exit(int);
 void free(void *);
 #ifdef __wasilibc_unmodified_upstream
 char *getenv(const char *);

--- a/libc-bottom-half/crt/crt1-command.c
+++ b/libc-bottom-half/crt/crt1-command.c
@@ -1,0 +1,18 @@
+#include <wasi/api.h>
+#include <stdlib.h>
+extern void __wasm_call_ctors(void);
+extern int __original_main(void);
+extern void __wasm_call_dtors(void);
+
+__attribute__((export_name("_start")))
+void _start(void) {
+    // Call `__original_main` which will either be the application's zero-argument
+    // `__original_main` function or a libc routine which calls `__main_void`.
+    // TODO: Call `main` directly once we no longer have to support old compilers.
+    int r = __original_main();
+
+    // If main exited successfully, just return, otherwise call `exit`.
+    if (r != 0) {
+        exit(r);
+    }
+}


### PR DESCRIPTION
This enables [new-style command support]. Instead of calling
`__wasm_call_ctors` and `__wasm_call_dtors` directly, this lets
wasm-ld automatically call them.

And, this comments out a use of "protected" visibility, since
[WebAssembly doesn't support it].

[new-style command support]: https://reviews.llvm.org/D81689
[WebAssembly doesn't support it]: https://reviews.llvm.org/D81688