### PR TITLE
Comment a use of `__attribute__((visibility("protected")))`.

### DIFF
--- a/libc-top-half/musl/src/internal/stdio_impl.h
+++ b/libc-top-half/musl/src/internal/stdio_impl.h
@@ -89,8 +89,10 @@ hidden int __towrite(FILE *);
 hidden void __stdio_exit(void);
 hidden void __stdio_exit_needed(void);
 
+#ifdef __wasilibc_unmodified_upstream // wasm has no "protected" visibility
 #if defined(__PIC__) && (100*__GNUC__+__GNUC_MINOR__ >= 303)
 __attribute__((visibility("protected")))
+#endif
 #endif
 int __overflow(FILE *, int), __uflow(FILE *);
 


### PR DESCRIPTION
This comments out a use of "protected" visibility, since
[WebAssembly doesn't support it].

[WebAssembly doesn't support it]: https://reviews.llvm.org/D81688