### PR TITLE
Activate the use of __heap_base

### DIFF
--- a/dlmalloc/src/malloc.c
+++ b/dlmalloc/src/malloc.c
@@ -4560,11 +4560,9 @@ static void* tmalloc_small(mstate m, size_t nb) {
 
 #if !ONLY_MSPACES
 
-#if 0 // Temporarily work around https://bugs.llvm.org/show_bug.cgi?id=43613
 #if __wasilibc_unmodified_upstream // Forward declaration of try_init_allocator.
 #else
 static void try_init_allocator(void);
-#endif
 #endif
 
 void* dlmalloc(size_t bytes) {
@@ -4595,13 +4593,11 @@ void* dlmalloc(size_t bytes) {
   ensure_initialization(); /* initialize in sys_alloc if not using locks */
 #endif
 
-#if 0 // Temporarily work around https://bugs.llvm.org/show_bug.cgi?id=43613
 #if __wasilibc_unmodified_upstream // Try to initialize the allocator.
 #else
   if (!is_initialized(gm)) {
     try_init_allocator();
   }
-#endif
 #endif
 
   if (!PREACTION(gm)) {
@@ -5213,8 +5209,7 @@ static void internal_inspect_all(mstate m,
 }
 #endif /* MALLOC_INSPECT_ALL */
 
-#if 0 // Temporarily work around https://bugs.llvm.org/show_bug.cgi?id=43613
-#ifdef __wasilibc_unmodified_upstream // Define a function that initializes the initial state of dlmalloc
+#ifdef __wasilibc_unmodified_upstream // Define a function that initializes the initial state of dlmalloc.
 #else
 /* ------------------ Exported try_init_allocator -------------------- */
 
@@ -5248,7 +5243,6 @@ static void try_init_allocator(void) {
   init_bins(gm);
   init_top(gm, (mchunkptr)base, initial_heap_size - TOP_FOOT_SIZE);
 }
-#endif
 #endif
 
 /* ------------------ Exported realloc, memalign, etc -------------------- */

--- a/expected/wasm32-wasi/undefined-symbols.txt
+++ b/expected/wasm32-wasi/undefined-symbols.txt
@@ -10,6 +10,7 @@ __floatsitf
 __floatunsitf
 __getf2
 __gttf2
+__heap_base
 __letf2
 __lttf2
 __netf2


### PR DESCRIPTION
This was temporary disabled by https://github.com/WebAssembly/wasi-libc/pull/132 due the LLVM [bug](https://bugs.llvm.org/show_bug.cgi?id=43613) that's been fixed.

Resolves #212.