### PR TITLE
Don't truncate directory cookies in `seekdir`/`telldir`

### DIFF
--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -260,6 +260,7 @@ __wasilibc_open_nomode
 __wasilibc_openat_nomode
 __wasilibc_register_preopened_fd
 __wasilibc_rmdirat
+__wasilibc_seekdir
 __wasilibc_tell
 __wasilibc_unlinkat
 __wasm_call_dtors

--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -2001,6 +2001,7 @@
 #define _CTYPE_H 
 #define _Complex_I (0.0f+1.0fi)
 #define _DIRENT_H 
+#define _DIRENT_HAVE_D_NAMLEN 
 #define _DIRENT_HAVE_D_TYPE 
 #define _ENDIAN_H 
 #define _ERRNO_H 

--- a/libc-bottom-half/cloudlibc/src/include/stdlib.h
+++ b/libc-bottom-half/cloudlibc/src/include/stdlib.h
@@ -131,9 +131,9 @@ double atof(const char *);
 int atoi(const char *);
 long atol(const char *);
 long long atoll(const char *);
+#endif
 void *bsearch(const void *, const void *, size_t, size_t,
               int (*)(const void *, const void *));
-#endif
 void *calloc(size_t, size_t);
 #ifdef __wasilibc_unmodified_upstream
 div_t div(int, int) __pure2;
@@ -175,8 +175,8 @@ int rand(void);
 long random(void);
 #endif
 void *realloc(void *, size_t);
-#ifdef __wasilibc_unmodified_upstream
 void *reallocarray(void *, size_t, size_t);
+#ifdef __wasilibc_unmodified_upstream
 double strtod(const char *__restrict, char **__restrict);
 double strtod_l(const char *__restrict, char **__restrict, __locale_t);
 float strtof(const char *__restrict, char **__restrict);

--- a/libc-bottom-half/cloudlibc/src/libc/dirent/dirent_impl.h
+++ b/libc-bottom-half/cloudlibc/src/libc/dirent/dirent_impl.h
@@ -26,6 +26,15 @@ struct _DIR {
   // Object returned by readdir().
   struct dirent *dirent;
   size_t dirent_size;
+
+#ifdef __wasm32__
+  // POSIX requires directory offsets to be represented as the C type `long`.
+  // That's 32 bits on wasm32. But WASI uses 64-bit cookies. So we add a
+  // layer of indirection.
+  __wasi_dircookie_t *offsets;
+  size_t offsets_len;
+  size_t offsets_allocated;
+#endif
 };
 
 #endif

--- a/libc-bottom-half/cloudlibc/src/libc/dirent/dirent_impl.h
+++ b/libc-bottom-half/cloudlibc/src/libc/dirent/dirent_impl.h
@@ -10,6 +10,19 @@
 
 struct dirent;
 
+_Static_assert(sizeof(__wasi_dirent_t) == sizeof(struct dirent),
+	       "layout of `struct dirent` should match `__wasi_dirent_t`");
+_Static_assert(offsetof(__wasi_dirent_t, d_next) == offsetof(struct dirent, d_loc),
+	       "layout of `struct dirent` should match `__wasi_dirent_t`");
+_Static_assert(offsetof(__wasi_dirent_t, d_ino) == offsetof(struct dirent, d_ino),
+	       "layout of `struct dirent` should match `__wasi_dirent_t`");
+_Static_assert(offsetof(__wasi_dirent_t, d_namlen) == offsetof(struct dirent, d_namlen),
+	       "layout of `struct dirent` should match `__wasi_dirent_t`");
+_Static_assert(offsetof(__wasi_dirent_t, d_type) == offsetof(struct dirent, d_type),
+	       "layout of `struct dirent` should match `__wasi_dirent_t`");
+_Static_assert(sizeof(__wasi_dirent_t) == offsetof(struct dirent, d_name),
+	       "layout of `struct dirent` should match `__wasi_dirent_t`");
+
 #define DIRENT_DEFAULT_BUFFER_SIZE 4096
 
 struct _DIR {

--- a/libc-bottom-half/cloudlibc/src/libc/dirent/fdclosedir.c
+++ b/libc-bottom-half/cloudlibc/src/libc/dirent/fdclosedir.c
@@ -11,6 +11,9 @@ int fdclosedir(DIR *dirp) {
   int fd = dirp->fd;
   free(dirp->buffer);
   free(dirp->dirent);
+#ifdef __wasm32__
+  free(dirp->offsets);
+#endif
   free(dirp);
   return fd;
 }

--- a/libc-bottom-half/cloudlibc/src/libc/dirent/fdopendir.c
+++ b/libc-bottom-half/cloudlibc/src/libc/dirent/fdopendir.c
@@ -46,5 +46,10 @@ DIR *fdopendir(int fd) {
   dirp->buffer_size = DIRENT_DEFAULT_BUFFER_SIZE;
   dirp->dirent = NULL;
   dirp->dirent_size = 1;
+#ifdef __wasm32__
+  dirp->offsets = NULL;
+  dirp->offsets_len = 0;
+  dirp->offsets_allocated = 0;
+#endif
   return dirp;
 }

--- a/libc-bottom-half/cloudlibc/src/libc/dirent/readdir.c
+++ b/libc-bottom-half/cloudlibc/src/libc/dirent/readdir.c
@@ -78,6 +78,7 @@ struct dirent *readdir(DIR *dirp) {
          offsetof(struct dirent, d_name) + entry.d_namlen + 1);
     struct dirent *dirent = dirp->dirent;
     dirent->d_ino = entry.d_ino;
+    dirent->d_loc = entry.d_next;
     dirent->d_type = entry.d_type;
     memcpy(dirent->d_name, name, entry.d_namlen);
     dirent->d_name[entry.d_namlen] = '\0';

--- a/libc-bottom-half/cloudlibc/src/libc/dirent/scandirat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/dirent/scandirat.c
@@ -93,6 +93,7 @@ int scandirat(int dirfd, const char *dir, struct dirent ***namelist,
     if (dirent == NULL)
       goto bad;
     dirent->d_ino = entry.d_ino;
+    dirent->d_loc = entry.d_next;
     dirent->d_type = entry.d_type;
     memcpy(dirent->d_name, name, entry.d_namlen);
     dirent->d_name[entry.d_namlen] = '\0';

--- a/libc-bottom-half/cloudlibc/src/libc/dirent/seekdir.c
+++ b/libc-bottom-half/cloudlibc/src/libc/dirent/seekdir.c
@@ -8,7 +8,11 @@
 
 void seekdir(DIR *dirp, long loc) {
   // Update cookie.
+#ifdef __wasm32__
+  dirp->cookie = dirp->offsets[(unsigned long)loc];
+#else
   dirp->cookie = (unsigned long)loc;
+#endif
   // Mark entire buffer as processed to force a read of new data.
   // TODO(ed): We could prevent a read if the offset is in the buffer.
   dirp->buffer_used = dirp->buffer_processed = dirp->buffer_size;

--- a/libc-bottom-half/cloudlibc/src/libc/dirent/seekdir.c
+++ b/libc-bottom-half/cloudlibc/src/libc/dirent/seekdir.c
@@ -5,14 +5,21 @@
 #include <dirent.h>
 
 #include "dirent_impl.h"
+#include "wasi/libc.h"
 
 void seekdir(DIR *dirp, long loc) {
   // Update cookie.
 #ifdef __wasm32__
-  dirp->cookie = dirp->offsets[(unsigned long)loc];
+  __wasi_dircookie_t cookie = dirp->offsets[(unsigned long)loc];
 #else
-  dirp->cookie = (unsigned long)loc;
+  __wasi_dircookie_t cookie = (unsigned long)loc;
 #endif
+  __wasilibc_seekdir(dirp, cookie);
+}
+
+void __wasilibc_seekdir(DIR *dirp, __wasi_dircookie_t loc) {
+  // Update cookie.
+  dirp->cookie = loc;
   // Mark entire buffer as processed to force a read of new data.
   // TODO(ed): We could prevent a read if the offset is in the buffer.
   dirp->buffer_used = dirp->buffer_processed = dirp->buffer_size;

--- a/libc-bottom-half/cloudlibc/src/libc/dirent/telldir.c
+++ b/libc-bottom-half/cloudlibc/src/libc/dirent/telldir.c
@@ -3,9 +3,63 @@
 // SPDX-License-Identifier: BSD-2-Clause
 
 #include <dirent.h>
+#include <errno.h>
+#include <stdlib.h>
 
 #include "dirent_impl.h"
 
+#ifdef __wasm32__
+static int compare_cookies(const void *a, const void *b) {
+    const __wasi_dircookie_t *da = (const __wasi_dircookie_t *)a;
+    const __wasi_dircookie_t *db = (const __wasi_dircookie_t *)b;
+    if (*da < *db) return -1;
+    if (*da > *db) return 1;
+    return 0;
+}
+#endif
+
 long telldir(DIR *dirp) {
-  return dirp->cookie;
+#ifdef __wasm32__
+    const __wasi_dircookie_t *match =
+        bsearch(&dirp->cookie,
+                dirp->offsets, dirp->offsets_len, sizeof(__wasi_dircookie_t),
+                compare_cookies);
+    if (match != NULL)
+        return (long)(match - dirp->offsets);
+
+    // Since the POSIX-mandated return type is `long`, which is only 32 bits on
+    // wasm32, store the actual offsets in a table and return an index.
+    if (dirp->offsets_len == dirp->offsets_allocated) {
+        size_t allocated = dirp->offsets_allocated;
+        if (allocated == 0) {
+            allocated = 4;
+        } else if (__builtin_umull_overflow(allocated, 2, &allocated)) {
+            goto enomem;
+        }
+        void *ptr =
+            reallocarray(dirp->offsets, allocated, sizeof(__wasi_dircookie_t));
+        if (ptr == NULL)
+            goto enomem;
+        dirp->offsets_allocated = allocated;
+        dirp->offsets = ptr;
+    }
+
+    size_t index = dirp->offsets_len;
+    size_t next_index = index + 1;
+    if (next_index > (size_t)LONG_MAX)
+        goto enomem;
+
+    dirp->offsets[index] = dirp->cookie;
+    dirp->offsets_len = next_index;
+    qsort(dirp->offsets, dirp->offsets_len, sizeof(__wasi_dircookie_t),
+          compare_cookies);
+    return index;
+
+enomem:
+    errno = ENOMEM;
+    return -1;
+#else
+    // On wasm64, we can just return the cookie directly.
+    return dirp->cookie;
+#endif
 }

--- a/libc-bottom-half/headers/public/__struct_dirent.h
+++ b/libc-bottom-half/headers/public/__struct_dirent.h
@@ -6,6 +6,9 @@
 #define _DIRENT_HAVE_D_TYPE
 
 struct dirent {
+    /// Similar to the traditional `d_off` field, however not compatible with
+    /// `seekdir`. Use with `__wasilibc_seekdir` instead.
+    unsigned long long d_loc;
     ino_t d_ino;
     unsigned char d_type;
     char d_name[];

--- a/libc-bottom-half/headers/public/__struct_dirent.h
+++ b/libc-bottom-half/headers/public/__struct_dirent.h
@@ -20,6 +20,9 @@ struct dirent {
     /// Type of filesystem entry (file, directory, etc.).
     unsigned char d_type;
 
+    // Padding so that the layout of `dirent` matches `__wasi_dirent_t`.
+    unsigned char __padding[3];
+
     /// The name of the entry, with a trailing NUL.
     char d_name[];
 };

--- a/libc-bottom-half/headers/public/__struct_dirent.h
+++ b/libc-bottom-half/headers/public/__struct_dirent.h
@@ -4,13 +4,23 @@
 #include <__typedef_ino_t.h>
 
 #define _DIRENT_HAVE_D_TYPE
+#define _DIRENT_HAVE_D_NAMLEN
 
 struct dirent {
     /// Similar to the traditional `d_off` field, however not compatible with
     /// `seekdir`. Use with `__wasilibc_seekdir` instead.
     unsigned long long d_loc;
+
+    /// The inode number of the entry.
     ino_t d_ino;
+
+    /// The length of the string in `d_name`, not including the trailing NUL.
+    unsigned d_namlen;
+
+    /// Type of filesystem entry (file, directory, etc.).
     unsigned char d_type;
+
+    /// The name of the entry, with a trailing NUL.
     char d_name[];
 };
 

--- a/libc-bottom-half/headers/public/wasi/libc.h
+++ b/libc-bottom-half/headers/public/wasi/libc.h
@@ -2,6 +2,7 @@
 #define __wasi_libc_h
 
 #include <__typedef_off_t.h>
+#include <__typedef_DIR.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,6 +32,10 @@ int __wasilibc_openat_nomode(int fd, const char *path, int oflag);
 /// Return the current file offset. Like `lseek(fd, 0, SEEK_CUR)`, but without
 /// depending on `lseek`.
 off_t __wasilibc_tell(int fd);
+
+/// Like `seekdir`, but takes a 64-bit directory location. This should be a
+/// value from a `d_loc` field rather than a `telldir` return value.
+void __wasilibc_seekdir(DIR *dirp, unsigned long long cookie);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
POSIX unfortunately requires the return type of `telldir` to be `long`, which is 32 bits on wasm32-wasi, so it isn't big enough to hold an actual directory cookie on WASI, which is 64 bits. For POSIX compatibility, add an indirection table in `dirent` so that `telldir` can return indices into the table rather than the actual cookies.

To accompany this change, add a `d_loc` field to the public `dirent`, which is similar to the traditional `d_off` field, except unlike `d_off` it's not tied to `seekdir`/`telldir` so it avoids the POSIX requirement that it have type `long`, and add a `__wasilibc_seekdir` interface to allow programs wishing to specialize for WASI to avoid the overhead of the indirection table.

This also adds a `d_namlen` field to the public `dirent` struct, which in addition to the changes above, allow it to match the layout of the raw WASI `dirent` struct, making the code simpler. This should also help avoid the need to call `strlen` on the `d_name` field in some situations.