### PR TITLE
Fix sinh's sign handling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,11 +23,15 @@ jobs:
       if: matrix.os == 'windows-latest'
 
     - name: Install llvm-nm (Windows)
-      shell: bash
       run: |
         rustup update stable
         rustup default stable
         rustup component add llvm-tools-preview
+      if: matrix.os == 'windows-latest'
+
+    - name: Register llvm-nm in environment (Windows)
+      shell: bash
+      run: |
         echo "WASM_NM=$(rustc --print sysroot|sed 's|C:|/c|'|sed 's|\\|/|g')/lib/rustlib/x86_64-pc-windows-msvc/bin/llvm-nm.exe" >> $GITHUB_ENV
       if: matrix.os == 'windows-latest'
 

--- a/libc-top-half/musl/src/math/sinh.c
+++ b/libc-top-half/musl/src/math/sinh.c
@@ -37,7 +37,7 @@ double sinh(double x)
 #ifdef __wasilibc_unmodified_upstream // Wasm doesn't have alternate rounding modes
 	t = __expo2(absx, 2*h);
 #else
-	t = __expo2(absx);
+	t = 2*h*__expo2(absx);
 #endif
 	return t;
 }

--- a/libc-top-half/musl/src/math/sinhf.c
+++ b/libc-top-half/musl/src/math/sinhf.c
@@ -29,7 +29,7 @@ float sinhf(float x)
 #ifdef __wasilibc_unmodified_upstream // Wasm doesn't have alternate rounding modes
 	t = __expo2f(absx, 2*h);
 #else
-	t = __expo2f(absx);
+	t = 2*h*__expo2f(absx);
 #endif
 	return t;
 }


### PR DESCRIPTION
In the musl 1.2.1 update, I made a change to disable the new code in
sinh for handling directed rounding modes, but I only incompletely
disabled it. This led to `sinh(-inf)` computing `inf` instead of `-inf`,
detected in [wasi-libc-test]. This patch fixes it.

[wasi-libc-test]: https://github.com/CraneStation/wasi-libc-test/tree/master/libc-test