### PR TITLE
Update README to include Archlinux AUR package link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ or libc++abi.a, respectively, so they may not be usable without
 extra setup. This is one of the things [wasi-sdk] simplifies, as it includes
 cross-compiled builds of compiler-rt, libc++.a, and libc++abi.a.
 
-## AUR package
-For Archlinux users, there's an AUR package tracking this git repo that can be installed under the name [wasi-libc-git].
+## Arch Linux AUR package
+For Arch Linux users, there's an unofficial AUR package tracking this git repo that can be installed under the name [wasi-libc-git].
 
 [wasi-sdk]: https://github.com/WebAssembly/wasi-sdk
 [wasi-libc-git]: https://aur.archlinux.org/packages/wasi-libc-git/

--- a/README.md
+++ b/README.md
@@ -43,4 +43,8 @@ or libc++abi.a, respectively, so they may not be usable without
 extra setup. This is one of the things [wasi-sdk] simplifies, as it includes
 cross-compiled builds of compiler-rt, libc++.a, and libc++abi.a.
 
+## AUR package
+For Archlinux users, there's an AUR package tracking this git repo that can be installed under the name [wasi-libc-git].
+
 [wasi-sdk]: https://github.com/WebAssembly/wasi-sdk
+[wasi-libc-git]: https://aur.archlinux.org/packages/wasi-libc-git/


### PR DESCRIPTION
Just created an AUR repo at https://aur.archlinux.org/packages/wasi-libc-git/. Add its link to README to help fellow Archlinux users.