### PR TITLE
Add a function to de-initialize the environment-variable state.

### DIFF
--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -296,6 +296,7 @@ __wasi_sock_send
 __wasi_sock_shutdown
 __wasilibc_access
 __wasilibc_cwd
+__wasilibc_deinitialize_environ
 __wasilibc_ensure_environ
 __wasilibc_environ
 __wasilibc_environ
@@ -307,6 +308,8 @@ __wasilibc_initialize_environ
 __wasilibc_link
 __wasilibc_link_newat
 __wasilibc_link_oldat
+__wasilibc_maybe_reinitialize_environ_eagerly
+__wasilibc_maybe_reinitialize_environ_eagerly
 __wasilibc_nocwd___wasilibc_rmdirat
 __wasilibc_nocwd___wasilibc_unlinkat
 __wasilibc_nocwd_faccessat

--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -304,6 +304,7 @@ __wasilibc_fd_renumber
 __wasilibc_find_abspath
 __wasilibc_find_relpath
 __wasilibc_find_relpath_alloc
+__wasilibc_get_environ
 __wasilibc_initialize_environ
 __wasilibc_link
 __wasilibc_link_newat

--- a/libc-bottom-half/headers/private/stdlib.h
+++ b/libc-bottom-half/headers/private/stdlib.h
@@ -4,3 +4,5 @@
 #include <stddef.h>
 
 #include_next <stdlib.h>
+
+int clearenv(void);

--- a/libc-bottom-half/headers/public/wasi/libc-environ.h
+++ b/libc-bottom-half/headers/public/wasi/libc-environ.h
@@ -1,6 +1,10 @@
 #ifndef __wasi_libc_environ_h
 #define __wasi_libc_environ_h
 
+/// This header file is a WASI-libc-specific interface, and is not needed by
+/// most programs. Most programs should just use the standard `getenv` and
+/// related APIs, which take care of all of the details automatically.
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -11,6 +15,14 @@ void __wasilibc_initialize_environ(void);
 
 /// If `__wasilibc_initialize_environ` has not yet been called, call it.
 void __wasilibc_ensure_environ(void);
+
+/// De-initialize the global environment variable state, so that subsequent
+/// calls to `__wasilibc_ensure_environ` call `__wasilibc_initialize_environ`.
+void __wasilibc_deinitialize_environ(void);
+
+/// Call `__wasilibc_initialize_environ` only if `environ` and `_environ` are
+/// referenced in the program.
+void __wasilibc_maybe_reinitialize_environ_eagerly(void);
 
 #ifdef __cplusplus
 }

--- a/libc-bottom-half/headers/public/wasi/libc-environ.h
+++ b/libc-bottom-half/headers/public/wasi/libc-environ.h
@@ -24,6 +24,11 @@ void __wasilibc_deinitialize_environ(void);
 /// referenced in the program.
 void __wasilibc_maybe_reinitialize_environ_eagerly(void);
 
+/// Return the value of the `environ` variable. Using `environ` directly
+/// requires eager initialization of the environment variables. Using this
+/// function instead of `environ` allows initialization to happen lazily.
+char **__wasilibc_get_environ(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/libc-bottom-half/sources/__wasilibc_environ.c
+++ b/libc-bottom-half/sources/__wasilibc_environ.c
@@ -1,0 +1,14 @@
+#include <wasi/libc-environ.h>
+
+extern char **__wasilibc_environ;
+
+// See the comments in libc-environ.h.
+char **__wasilibc_get_environ(void) {
+    // Perform lazy initialization if needed.
+    __wasilibc_ensure_environ();
+
+    // Return `environ`. Use the `__wasilibc_`-prefixed name so that we don't
+    // pull in the `environ` symbol directly, which would lead to eager
+    // initialization being done instead.
+    return __wasilibc_environ;
+}

--- a/libc-bottom-half/sources/__wasilibc_initialize_environ.c
+++ b/libc-bottom-half/sources/__wasilibc_initialize_environ.c
@@ -75,3 +75,20 @@ oserr:
 software:
     _Exit(EX_SOFTWARE);
 }
+
+// See the comments in libc-environ.h.
+void __wasilibc_deinitialize_environ(void) {
+    if (__wasilibc_environ != (char **)-1) {
+        // Let libc-top-half clear the old environment-variable strings.
+        clearenv();
+        // Set the pointer to the special init value.
+        __wasilibc_environ = (char **)-1;
+    }
+}
+
+// See the comments in libc-environ.h.
+__attribute__((weak))
+void __wasilibc_maybe_reinitialize_environ_eagerly(void) {
+    // This version does nothing. It may be overridden by a version which does
+    // something if `environ` is used.
+}

--- a/libc-bottom-half/sources/environ.c
+++ b/libc-bottom-half/sources/environ.c
@@ -24,3 +24,10 @@ __attribute__((constructor(50)))
 static void __wasilibc_initialize_environ_eagerly(void) {
     __wasilibc_initialize_environ();
 }
+
+// See the comments in libc-environ.h.
+void __wasilibc_maybe_reinitialize_environ_eagerly(void) {
+    // This translation unit is linked in if `environ` is used, meaning we need
+    // to eagerly reinitialize the environment variables.
+    __wasilibc_initialize_environ();
+}


### PR DESCRIPTION
Add a `__wasilibc_deinit_environ` function which clears the current
environment variable state to the state where next time the environment
variable functions are called, they'll reinitialize the environment.

And add a `__wasilibc_maybe_reinitialize_environ_eagerly` function to
reinitialize the environment variable state if `environ` or `_environ`
are needed.

These functions are needed by wizer to be able to suspend and resume
a program and have it read new environment variables from the host
environment; see bytecodealliance/wizer#8 for background.