### PR TITLE
Enable support for `utimes` and `futimesat`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,7 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
         env/setenv.c \
         env/unsetenv.c \
         unistd/posix_close.c \
+        stat/futimesat.c \
     ) \
     $(filter-out %/procfdname.c %/syscall.c %/syscall_ret.c %/vdso.c %/version.c, \
                  $(wildcard $(LIBC_TOP_HALF_MUSL_SRC_DIR)/internal/*.c)) \

--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -75,6 +75,7 @@ __funcs_on_exit
 __funcs_on_exit
 __funcs_on_quick_exit
 __funcs_on_quick_exit
+__futimesat
 __fwritable
 __fwritex
 __fwriting
@@ -643,6 +644,7 @@ ftello64
 ftime
 ftruncate
 futimens
+futimesat
 fwide
 fwprintf
 fwrite
@@ -1115,6 +1117,7 @@ uselocale
 usleep
 utime
 utimensat
+utimes
 vasprintf
 vdprintf
 versionsort

--- a/libc-top-half/musl/include/sys/time.h
+++ b/libc-top-half/musl/include/sys/time.h
@@ -23,9 +23,7 @@ struct itimerval {
 int getitimer (int, struct itimerval *);
 int setitimer (int, const struct itimerval *__restrict, struct itimerval *__restrict);
 #endif
-#ifdef __wasilibc_unmodified_upstream /* WASI libc doesn't build the legacy functions */
 int utimes (const char *, const struct timeval [2]);
-#endif
 
 #if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
 struct timezone {
@@ -34,7 +32,9 @@ struct timezone {
 };
 #ifdef __wasilibc_unmodified_upstream /* WASI libc doesn't build the legacy functions */
 int futimes(int, const struct timeval [2]);
+#endif
 int futimesat(int, const char *, const struct timeval [2]);
+#ifdef __wasilibc_unmodified_upstream /* WASI libc doesn't build the legacy functions */
 int lutimes(const char *, const struct timeval [2]);
 #endif
 #ifdef __wasilibc_unmodified_upstream /* WASI has no way to set the time */

--- a/libc-top-half/musl/src/stat/futimesat.c
+++ b/libc-top-half/musl/src/stat/futimesat.c
@@ -2,7 +2,9 @@
 #include <sys/time.h>
 #include <sys/stat.h>
 #include <errno.h>
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 #include "syscall.h"
+#endif
 
 int __futimesat(int dirfd, const char *pathname, const struct timeval times[2])
 {
@@ -11,7 +13,12 @@ int __futimesat(int dirfd, const char *pathname, const struct timeval times[2])
 		int i;
 		for (i=0; i<2; i++) {
 			if (times[i].tv_usec >= 1000000ULL)
+#ifdef __wasilibc_unmodified_upstream // WASI has no syscall
 				return __syscall_ret(-EINVAL);
+#else
+				errno = EINVAL;
+				return -1;
+#endif
 			ts[i].tv_sec = times[i].tv_sec;
 			ts[i].tv_nsec = times[i].tv_usec * 1000;
 		}


### PR DESCRIPTION
These can both be implemented in terms of `utimensat`.