### PR TITLE
Implement emulated support for `getpid`.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,6 +56,8 @@ LIBWASI_EMULATED_MMAN_SOURCES = \
     $(shell find $(LIBC_BOTTOM_HALF_DIR)/mman -name \*.c)
 LIBWASI_EMULATED_PROCESS_CLOCKS_SOURCES = \
     $(shell find $(LIBC_BOTTOM_HALF_DIR)/clocks -name \*.c)
+LIBWASI_EMULATED_GETPID_SOURCES = \
+    $(shell find $(LIBC_BOTTOM_HALF_DIR)/getpid -name \*.c)
 LIBWASI_EMULATED_SIGNAL_SOURCES = \
     $(shell find $(LIBC_BOTTOM_HALF_DIR)/signal -name \*.c)
 LIBWASI_EMULATED_SIGNAL_MUSL_SOURCES = \
@@ -232,6 +234,7 @@ MUSL_PRINTSCAN_LONG_DOUBLE_OBJS = $(patsubst %.o,%.long-double.o,$(MUSL_PRINTSCA
 MUSL_PRINTSCAN_NO_FLOATING_POINT_OBJS = $(patsubst %.o,%.no-floating-point.o,$(MUSL_PRINTSCAN_OBJS))
 LIBWASI_EMULATED_MMAN_OBJS = $(call objs,$(LIBWASI_EMULATED_MMAN_SOURCES))
 LIBWASI_EMULATED_PROCESS_CLOCKS_OBJS = $(call objs,$(LIBWASI_EMULATED_PROCESS_CLOCKS_SOURCES))
+LIBWASI_EMULATED_GETPID_OBJS = $(call objs,$(LIBWASI_EMULATED_GETPID_SOURCES))
 LIBWASI_EMULATED_SIGNAL_OBJS = $(call objs,$(LIBWASI_EMULATED_SIGNAL_SOURCES))
 LIBWASI_EMULATED_SIGNAL_MUSL_OBJS = $(call objs,$(LIBWASI_EMULATED_SIGNAL_MUSL_SOURCES))
 
@@ -337,6 +340,8 @@ $(SYSROOT_LIB)/libwasi-emulated-mman.a: $(LIBWASI_EMULATED_MMAN_OBJS)
 
 $(SYSROOT_LIB)/libwasi-emulated-process-clocks.a: $(LIBWASI_EMULATED_PROCESS_CLOCKS_OBJS)
 
+$(SYSROOT_LIB)/libwasi-emulated-getpid.a: $(LIBWASI_EMULATED_GETPID_OBJS)
+
 $(SYSROOT_LIB)/libwasi-emulated-signal.a: $(LIBWASI_EMULATED_SIGNAL_OBJS) $(LIBWASI_EMULATED_SIGNAL_MUSL_OBJS)
 
 %.a:
@@ -441,6 +446,7 @@ libc: include_dirs \
     $(SYSROOT_LIB)/libc-printscan-no-floating-point.a \
     $(SYSROOT_LIB)/libwasi-emulated-mman.a \
     $(SYSROOT_LIB)/libwasi-emulated-process-clocks.a \
+    $(SYSROOT_LIB)/libwasi-emulated-getpid.a \
     $(SYSROOT_LIB)/libwasi-emulated-signal.a
 
 finish: startup_files libc

--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -669,6 +669,7 @@ getline
 getopt
 getopt_long
 getopt_long_only
+getpid
 getrusage
 getsockopt
 getsubopt

--- a/libc-bottom-half/getpid/getpid.c
+++ b/libc-bottom-half/getpid/getpid.c
@@ -1,0 +1,6 @@
+#include <unistd.h>
+
+pid_t getpid(void) {
+    // Return an arbitrary value, greater than 1 which is special.
+    return 42;
+}

--- a/libc-top-half/musl/include/unistd.h
+++ b/libc-top-half/musl/include/unistd.h
@@ -145,8 +145,17 @@ int fexecve(int, char *const [], char *const []);
 #endif
 _Noreturn void _exit(int);
 
-#ifdef __wasilibc_unmodified_upstream /* WASI has no getpid etc. */
+#if defined(__wasilibc_unmodified_upstream) || defined(_WASI_EMULATED_GETPID)
 pid_t getpid(void);
+#else
+__attribute__((__deprecated__(
+"WASI lacks process identifiers; to enable emulation of the `getpid` function using "
+"a placeholder value, which doesn't reflect the host PID of the program, "
+"compile with -D_WASI_EMULATED_GETPID and link with -lwasi-emulated-getpid"
+)))
+pid_t getpid(void);
+#endif
+#ifdef __wasilibc_unmodified_upstream /* WASI has no getpid etc. */
 pid_t getppid(void);
 pid_t getpgrp(void);
 pid_t getpgid(pid_t);


### PR DESCRIPTION
Add a simple `getpid` emulation function which just returns a fixed
value, for applications that just use it for logging.