### PR TITLE
chdir: fixing a malloc'ed buffer that was not large enough (possible mem corruption)

### DIFF
--- a/libc-bottom-half/sources/chdir.c
+++ b/libc-bottom-half/sources/chdir.c
@@ -46,7 +46,7 @@ int chdir(const char *path)
     size_t len = strlen(abs) + 1;
     int copy_relative = strcmp(relative_buf, ".") != 0;
     int mid = copy_relative && abs[0] != 0;
-    char *new_cwd = malloc(len + (copy_relative ? strlen(relative_buf) + mid: 0));
+    char *new_cwd = malloc(len + (copy_relative ? strlen(relative_buf) + mid: 0)+1);
     if (new_cwd == NULL) {
         errno = ENOMEM;
         return -1;
@@ -54,7 +54,7 @@ int chdir(const char *path)
     new_cwd[0] = '/';
     strcpy(new_cwd + 1, abs);
     if (mid)
-        new_cwd[strlen(abs) + 1] = '/';
+        new_cwd[len] = '/';
     if (copy_relative)
         strcpy(new_cwd + 1 + mid + strlen(abs), relative_buf);
 
@@ -95,9 +95,10 @@ static const char *make_absolute(const char *path) {
     int need_slash = __wasilibc_cwd[cwd_len - 1] == '/' ? 0 : 1;
     size_t alloc_len = cwd_len + path_len + 1 + need_slash;
     if (alloc_len > make_absolute_len) {
-        make_absolute_buf = realloc(make_absolute_buf, alloc_len);
-        if (make_absolute_buf == NULL)
+        char *tmp = realloc(make_absolute_buf, alloc_len);
+        if (tmp == NULL)
             return NULL;
+        make_absolute_buf = tmp;
         make_absolute_len = alloc_len;
     }
     strcpy(make_absolute_buf, __wasilibc_cwd);

--- a/libc-bottom-half/sources/chdir.c
+++ b/libc-bottom-half/sources/chdir.c
@@ -43,10 +43,10 @@ int chdir(const char *path)
     //
     // If `relative_buf` is equal to "." or `abs` is equal to the empty string,
     // however, we skip that part and the middle slash.
-    size_t len = strlen(abs) + 1;
+    size_t abs_len = strlen(abs);
     int copy_relative = strcmp(relative_buf, ".") != 0;
     int mid = copy_relative && abs[0] != 0;
-    char *new_cwd = malloc(len + (copy_relative ? strlen(relative_buf) + mid: 0)+1);
+    char *new_cwd = malloc(1 + abs_len + mid + (copy_relative ? strlen(relative_buf) : 0) + 1);
     if (new_cwd == NULL) {
         errno = ENOMEM;
         return -1;
@@ -54,9 +54,9 @@ int chdir(const char *path)
     new_cwd[0] = '/';
     strcpy(new_cwd + 1, abs);
     if (mid)
-        new_cwd[len] = '/';
+        new_cwd[1 + abs_len] = '/';
     if (copy_relative)
-        strcpy(new_cwd + 1 + mid + strlen(abs), relative_buf);
+        strcpy(new_cwd + 1 + abs_len + mid, relative_buf);
 
     // And set our new malloc'd buffer into the global cwd, freeing the
     // previous one if necessary.


### PR DESCRIPTION
I started using `chdir` in my code, and the effect was that it occasionally inserted random bytes into paths (e.g. opening `/abc/def` would try to open `/abc\xab/def`). This PR fixes the problem - it turns out the buffer for the current working directory was not always large enough.