### PR TITLE
Fix compilation with clang trunk

### DIFF
--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -2457,7 +2457,6 @@
 #define __FLT_DENORM_MIN__ 1.40129846e-45F
 #define __FLT_DIG__ 6
 #define __FLT_EPSILON__ 1.19209290e-7F
-#define __FLT_EVAL_METHOD__ 0
 #define __FLT_HAS_DENORM__ 1
 #define __FLT_HAS_INFINITY__ 1
 #define __FLT_HAS_QUIET_NAN__ 1

--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -3002,6 +3002,8 @@
 #define __alignof_is_defined 1
 #define __bitop(x,i,o) ((x)[(i)/8] o (1<<(i)%8))
 #define __bool_true_false_are_defined 1
+#define __clang_literal_encoding__ "UTF-8"
+#define __clang_wide_literal_encoding__ "UTF-32"
 #define __inline inline
 #define __restrict restrict
 #define __tg_complex(fun,x) (__RETCAST_CX(x)( __FLTCX((x)+I) && __IS_FP(x) ? fun ## f (x) : __LDBLCX((x)+I) ? fun ## l (x) : fun(x) ))


### PR DESCRIPTION
This PR adds `-Wno-unused-but-set-variable` to CFLAGS (required by [strfmon.c:12](https://github.com/WebAssembly/wasi-libc/blob/main/libc-top-half/musl/src/locale/strfmon.c#L12)) and adds two encoding-related preprocessor macros to [predefined-macros.txt](https://github.com/WebAssembly/wasi-libc/blob/main/expected/wasm32-wasi/predefined-macros.txt) (added in clang trunk by https://github.com/llvm/llvm-project/commit/701d70d4c25c4e02b303ba6dee1495708496f615). With these changes, wasi-libc compiles with the current clang trunk.