### PR TITLE
Ignore -Wunused-but-set-variable warnings.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,7 +198,8 @@ CFLAGS += -Wall -Wextra -Werror \
   -Wno-ignored-attributes \
   -Wno-missing-braces \
   -Wno-ignored-pragmas \
-  -Wno-unused-but-set-variable
+  -Wno-unused-but-set-variable \
+  -Wno-unknown-warning-option
 
 # Configure support for threads.
 ifeq ($(THREAD_MODEL), single)

--- a/Makefile
+++ b/Makefile
@@ -197,7 +197,8 @@ CFLAGS += -Wall -Wextra -Werror \
   -Wno-unused-function \
   -Wno-ignored-attributes \
   -Wno-missing-braces \
-  -Wno-ignored-pragmas
+  -Wno-ignored-pragmas \
+  -Wno-unused-but-set-variable
 
 # Configure support for threads.
 ifeq ($(THREAD_MODEL), single)


### PR DESCRIPTION
This come up when compiling musl with newer clang releases and
appear to be harmless.