### PR TITLE
Reset the register stack and counter

### DIFF
--- a/libc-top-half/musl/src/exit/atexit.c
+++ b/libc-top-half/musl/src/exit/atexit.c
@@ -37,6 +37,9 @@ void __funcs_on_exit()
 		func(arg);
 		LOCK(lock);
 	}
+	/* reset */
+	head = &builtin;
+	slot = 0;
 }
 
 void __cxa_finalize(void *dso)


### PR DESCRIPTION
It turns out that *clang* will surrounding every exported function with `__wasm_call_ctors` and `__wasm_call_dtors`. `__wasm_call_ctors` will call `__cxa_atexit` to register functions which will be triggered by `__wasm_call_dtors`. In other words, the loop of `__cxa_atexit` and `__funcs_on_exit` will be processed multiple times.

but the value of `head` and the value of `slot` will be `NULL` and `COUNT` after ending the for loop in `__funcs_on_exit`. The wrong value leads:
- a memory leak at [L55](https://github.com/WebAssembly/wasi-libc/blob/ad5133410f66b93a2381db5b542aad5e0964db96/libc-top-half/musl/src/exit/atexit.c#L55)
- bind an empty register list but a logically full list at [L60](https://github.com/WebAssembly/wasi-libc/blob/ad5133410f66b93a2381db5b542aad5e0964db96/libc-top-half/musl/src/exit/atexit.c#L60). It will bind *builtin* as a full list but actually it is empty after `__funcs_on_exit`.