### PR TITLE
Try to restore some build system conventions in a low-impact way

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ jobs:
         curl -fsSLO https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/LLVM-10.0.0-win64.exe
         7z x LLVM-10.0.0-win64.exe -y -o"llvm"
         echo "$(pwd)/llvm/bin" >> $GITHUB_PATH
-        echo "WASM_CC=$(pwd)/llvm/bin/clang.exe" >> $GITHUB_ENV
-        echo "WASM_AR=$(pwd)/llvm/bin/llvm-ar.exe" >> $GITHUB_ENV
-        echo "WASM_NM=$(pwd)/llvm/bin/llvm-nm.exe" >> $GITHUB_ENV
+        echo "CC=$(pwd)/llvm/bin/clang.exe" >> $GITHUB_ENV
+        echo "AR=$(pwd)/llvm/bin/llvm-ar.exe" >> $GITHUB_ENV
+        echo "NM=$(pwd)/llvm/bin/llvm-nm.exe" >> $GITHUB_ENV
       if: matrix.os == 'windows-latest'
 
     - name: Override llvm-nm with one from rustup (Windows)
@@ -29,7 +29,7 @@ jobs:
         rustup update stable
         rustup default stable
         rustup component add llvm-tools-preview
-        echo "WASM_NM=$(rustc --print sysroot|sed 's|C:|/c|'|sed 's|\\|/|g')/lib/rustlib/x86_64-pc-windows-msvc/bin/llvm-nm.exe" >> $GITHUB_ENV
+        echo "NM=$(rustc --print sysroot|sed 's|C:|/c|'|sed 's|\\|/|g')/lib/rustlib/x86_64-pc-windows-msvc/bin/llvm-nm.exe" >> $GITHUB_ENV
       if: matrix.os == 'windows-latest'
 
     - name: Install LLVM tools (MacOS)
@@ -38,9 +38,9 @@ jobs:
         curl -sSfL https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-apple-darwin.tar.xz | tar xJf -
         export CLANG_DIR=`pwd`/clang+llvm-10.0.0-x86_64-apple-darwin/bin
         echo "$CLANG_DIR" >> $GITHUB_PATH
-        echo "WASM_CC=$CLANG_DIR/clang" >> $GITHUB_ENV
-        echo "WASM_AR=$CLANG_DIR/llvm-ar" >> $GITHUB_ENV
-        echo "WASM_NM=$CLANG_DIR/llvm-nm" >> $GITHUB_ENV
+        echo "CC=$CLANG_DIR/clang" >> $GITHUB_ENV
+        echo "AR=$CLANG_DIR/llvm-ar" >> $GITHUB_ENV
+        echo "NM=$CLANG_DIR/llvm-nm" >> $GITHUB_ENV
       if: matrix.os == 'macos-latest'
 
     - name: Install LLVM tools (Linux)
@@ -49,9 +49,9 @@ jobs:
         curl -sSfL https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04.tar.xz | tar xJf -
         export CLANG_DIR=`pwd`/clang+llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04/bin
         echo "$CLANG_DIR" >> $GITHUB_PATH
-        echo "WASM_CC=$CLANG_DIR/clang" >> $GITHUB_ENV
-        echo "WASM_AR=$CLANG_DIR/llvm-ar" >> $GITHUB_ENV
-        echo "WASM_NM=$CLANG_DIR/llvm-nm" >> $GITHUB_ENV
+        echo "CC=$CLANG_DIR/clang" >> $GITHUB_ENV
+        echo "AR=$CLANG_DIR/llvm-ar" >> $GITHUB_ENV
+        echo "NM=$CLANG_DIR/llvm-nm" >> $GITHUB_ENV
       if: matrix.os == 'ubuntu-latest'
 
     - name: Build libc

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ To build a WASI sysroot from source, obtain a WebAssembly-supporting C compiler
 and then run:
 
 ```sh
-make WASM_CC=/path/to/clang/with/wasm/support \
-     WASM_AR=/path/to/llvm-ar \
-     WASM_NM=/path/to/llvm-nm
+make CC=/path/to/clang/with/wasm/support \
+     AR=/path/to/llvm-ar \
+     NM=/path/to/llvm-nm
 ```
 
 This makes a directory called "sysroot", by default. See the top of the Makefile


### PR DESCRIPTION
Fixes #269

The "don't move the variables independently if you want to `make
install`" part is a gross, but as neither `wasi-sdk` or Nixpkgs actually
needs `make install` (we both can just build right into the directories
we want) I figured it wasn't actually so heinous in practice.