### PR TITLE
Fix futimens error handling.

### DIFF
--- a/libc-top-half/musl/src/stat/futimesat.c
+++ b/libc-top-half/musl/src/stat/futimesat.c
@@ -12,12 +12,14 @@ int __futimesat(int dirfd, const char *pathname, const struct timeval times[2])
 	if (times) {
 		int i;
 		for (i=0; i<2; i++) {
-			if (times[i].tv_usec >= 1000000ULL)
 #ifdef __wasilibc_unmodified_upstream // WASI has no syscall
+			if (times[i].tv_usec >= 1000000ULL)
 				return __syscall_ret(-EINVAL);
 #else
+			if (times[i].tv_usec >= 1000000ULL) {
 				errno = EINVAL;
 				return -1;
+			}
 #endif
 			ts[i].tv_sec = times[i].tv_sec;
 			ts[i].tv_nsec = times[i].tv_usec * 1000;


### PR DESCRIPTION
Fix a bug introduced in #242 noticed [here]: if `tv_usec` is out of
range, then properly return an error code.

[here]: https://github.com/WebAssembly/wasi-libc/commit/079adff840032c3455eb1cb34dc9ceaa0b2bfc0c#r69631767