### PR TITLE
feat: add support for accept and accept4

### DIFF
--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -363,6 +363,8 @@ _start
 a64l
 abort
 abs
+accept
+accept4
 access
 acos
 acosf

--- a/libc-bottom-half/sources/accept.c
+++ b/libc-bottom-half/sources/accept.c
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: BSD-2-Clause
+
+#include <sys/socket.h>
+
+#include <assert.h>
+#include <wasi/api.h>
+#include <errno.h>
+#include <string.h>
+
+int accept(int socket, struct sockaddr *restrict addr, socklen_t *restrict addrlen) {
+  int ret = -1;
+
+  __wasi_errno_t error = __wasi_sock_accept(socket, 0, &ret);
+
+  if (error != 0) {
+    errno = error;
+    return -1;
+  }
+
+  // Clear sockaddr to indicate undefined address
+  memset(addr, 0, *addrlen);
+  // might be AF_UNIX or AF_INET
+  addr->sa_family = AF_UNSPEC;
+  *addrlen = sizeof(struct sockaddr);
+
+  return ret;
+}
+
+int accept4(int socket, struct sockaddr *restrict addr, socklen_t *restrict addrlen, int flags) {
+  int ret = -1;
+
+  if (flags & ~(SOCK_NONBLOCK | SOCK_CLOEXEC)) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  __wasi_errno_t error = __wasi_sock_accept(socket, (flags & SOCK_NONBLOCK) ? __WASI_FDFLAGS_NONBLOCK : 0, &ret);
+
+  if (error != 0) {
+    errno = error;
+    return -1;
+  }
+
+  // Clear sockaddr to indicate undefined address
+  memset(addr, 0, *addrlen);
+  // might be AF_UNIX or AF_INET
+  addr->sa_family = AF_UNSPEC;
+  *addrlen = sizeof(struct sockaddr);
+
+  return ret;
+}

--- a/libc-top-half/musl/include/sys/socket.h
+++ b/libc-top-half/musl/include/sys/socket.h
@@ -404,9 +404,10 @@ int shutdown (int, int);
 int bind (int, const struct sockaddr *, socklen_t);
 int connect (int, const struct sockaddr *, socklen_t);
 int listen (int, int);
+#endif
+
 int accept (int, struct sockaddr *__restrict, socklen_t *__restrict);
 int accept4(int, struct sockaddr *__restrict, socklen_t *__restrict, int);
-#endif
 
 #ifdef __wasilibc_unmodified_upstream /* WASI has no getsockname/getpeername */
 int getsockname (int, struct sockaddr *__restrict, socklen_t *__restrict);


### PR DESCRIPTION
Since the socket address of the accepted socket is unknown,
all bytes are set to zero and the length is truncated to the size
of the generic `struct sockaddr`.

Fixes: #284 
Supersedes: #286 

Signed-off-by: Harald Hoyer <harald@profian.com>