### PR TITLE
Exclude C++ headers from the generated include-all.c program.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -513,10 +513,10 @@ check-symbols: startup_files libc
 	    > "$(SYSROOT_LIB)/libc.imports"
 
 	#
-	# Generate a test file that includes all public header files.
+	# Generate a test file that includes all public C header files.
 	#
 	cd "$(SYSROOT_INC)" && \
-	  for header in $$(find . -type f -not -name mman.h -not -name signal.h -not -name times.h -not -name resource.h |grep -v /bits/); do \
+	  for header in $$(find . -type f -not -name mman.h -not -name signal.h -not -name times.h -not -name resource.h |grep -v /bits/ |grep -v /c++/); do \
 	      echo '#include <'$$header'>' | sed 's/\.\///' ; \
 	done |LC_ALL=C sort >$(SYSROOT_SHARE)/include-all.c ; \
 	cd - >/dev/null


### PR DESCRIPTION
The order that things happen in appears to have changed, and the
include-all.c script is now generated at a time when there can be
C++ headers in the sysroot, so adjust the script to exclude C++
headers.