### PR TITLE
Fix utimensat to avoid passing uninitialized values into WASI calls.

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/sys/stat/stat_impl.h
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/stat/stat_impl.h
@@ -75,14 +75,18 @@ static inline bool utimens_get_timestamps(const struct timespec *times,
   if (times == NULL) {
     // Update both timestamps.
     *flags = __WASI_FSTFLAGS_ATIM_NOW | __WASI_FSTFLAGS_MTIM_NOW;
+    *st_atim = (__wasi_timestamp_t) { 0 };
+    *st_mtim = (__wasi_timestamp_t) { 0 };
   } else {
     // Set individual timestamps.
     *flags = 0;
     switch (times[0].tv_nsec) {
       case UTIME_NOW:
         *flags |= __WASI_FSTFLAGS_ATIM_NOW;
+        *st_atim = (__wasi_timestamp_t) { 0 };
         break;
       case UTIME_OMIT:
+        *st_atim = (__wasi_timestamp_t) { 0 };
         break;
       default:
         *flags |= __WASI_FSTFLAGS_ATIM;
@@ -94,8 +98,10 @@ static inline bool utimens_get_timestamps(const struct timespec *times,
     switch (times[1].tv_nsec) {
       case UTIME_NOW:
         *flags |= __WASI_FSTFLAGS_MTIM_NOW;
+        *st_mtim = (__wasi_timestamp_t) { 0 };
         break;
       case UTIME_OMIT:
+        *st_mtim = (__wasi_timestamp_t) { 0 };
         break;
       default:
         *flags |= __WASI_FSTFLAGS_MTIM;


### PR DESCRIPTION
Previously, utimensat would leave the mtim and/or atim timestamps
uninitialized when the `MTIM_NOW` or `ATIM_NOW` were in use, because
that means the respective timestamps are not used.

However, clang now automatically adds `noundef` to the arguments in
functions like `__wasi_path_filestat_set_times`, and there are cases
where simplifycfg can see paths where the uninitialized values are
passed to those `noundef` arguments.

To fix this, change the utimens code to zero out the timestamps when
they aren't in use, to avoid passing uninitialized arguments.