### PR TITLE
Fix `gettimeofday` to correctly handle a null argument.

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/sys/time/gettimeofday.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/time/gettimeofday.c
@@ -9,8 +9,10 @@
 #include <wasi/api.h>
 
 int gettimeofday(struct timeval *restrict tp, void *tz) {
-  __wasi_timestamp_t ts = 0;
-  (void)__wasi_clock_time_get(__WASI_CLOCKID_REALTIME, 1000, &ts);
-  *tp = timestamp_to_timeval(ts);
+  if (tp != NULL) {
+    __wasi_timestamp_t ts = 0;
+    (void)__wasi_clock_time_get(__WASI_CLOCKID_REALTIME, 1000, &ts);
+    *tp = timestamp_to_timeval(ts);
+  }
   return 0;
 }


### PR DESCRIPTION
`gettimeofday` is defined to do nothing if passed NULL.