### PR TITLE
Sort lists of input files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,9 @@ LIBC_BOTTOM_HALF_HEADERS_PUBLIC = $(LIBC_BOTTOM_HALF_DIR)/headers/public
 LIBC_BOTTOM_HALF_HEADERS_PRIVATE = $(LIBC_BOTTOM_HALF_DIR)/headers/private
 LIBC_BOTTOM_HALF_SOURCES = $(LIBC_BOTTOM_HALF_DIR)/sources
 LIBC_BOTTOM_HALF_ALL_SOURCES = \
+    $(sort \
     $(shell find $(LIBC_BOTTOM_HALF_CLOUDLIBC_SRC) -name \*.c) \
-    $(shell find $(LIBC_BOTTOM_HALF_SOURCES) -name \*.c)
+    $(shell find $(LIBC_BOTTOM_HALF_SOURCES) -name \*.c))
 
 # FIXME(https://reviews.llvm.org/D85567) - due to a bug in LLD the weak
 # references to a function defined in `chdir.c` only work if `chdir.c` is at the
@@ -61,13 +62,13 @@ LIBC_BOTTOM_HALF_ALL_SOURCES := $(filter-out $(LIBC_BOTTOM_HALF_SOURCES)/chdir.c
 LIBC_BOTTOM_HALF_ALL_SOURCES := $(LIBC_BOTTOM_HALF_ALL_SOURCES) $(LIBC_BOTTOM_HALF_SOURCES)/chdir.c
 
 LIBWASI_EMULATED_MMAN_SOURCES = \
-    $(shell find $(LIBC_BOTTOM_HALF_DIR)/mman -name \*.c)
+    $(sort $(shell find $(LIBC_BOTTOM_HALF_DIR)/mman -name \*.c))
 LIBWASI_EMULATED_PROCESS_CLOCKS_SOURCES = \
-    $(shell find $(LIBC_BOTTOM_HALF_DIR)/clocks -name \*.c)
+    $(sort $(shell find $(LIBC_BOTTOM_HALF_DIR)/clocks -name \*.c))
 LIBWASI_EMULATED_GETPID_SOURCES = \
-    $(shell find $(LIBC_BOTTOM_HALF_DIR)/getpid -name \*.c)
+    $(sort $(shell find $(LIBC_BOTTOM_HALF_DIR)/getpid -name \*.c))
 LIBWASI_EMULATED_SIGNAL_SOURCES = \
-    $(shell find $(LIBC_BOTTOM_HALF_DIR)/signal -name \*.c)
+    $(sort $(shell find $(LIBC_BOTTOM_HALF_DIR)/signal -name \*.c))
 LIBWASI_EMULATED_SIGNAL_MUSL_SOURCES = \
     $(LIBC_TOP_HALF_MUSL_SRC_DIR)/signal/psignal.c \
     $(LIBC_TOP_HALF_MUSL_SRC_DIR)/string/strsignal.c
@@ -199,7 +200,7 @@ LIBC_TOP_HALF_HEADERS_PRIVATE = $(LIBC_TOP_HALF_DIR)/headers/private
 LIBC_TOP_HALF_SOURCES = $(LIBC_TOP_HALF_DIR)/sources
 LIBC_TOP_HALF_ALL_SOURCES = \
     $(LIBC_TOP_HALF_MUSL_SOURCES) \
-    $(shell find $(LIBC_TOP_HALF_SOURCES) -name \*.c)
+    $(sort $(shell find $(LIBC_TOP_HALF_SOURCES) -name \*.c))
 
 # Add any extra flags
 CFLAGS = $(EXTRA_CFLAGS)


### PR DESCRIPTION
Sort lists of input files
for reproducible `.a` files in spite of non-deterministic
filesystem readdir order

Without this patch, find returned files in filesystem order
and llvm-ar used that order to create .a files.

This PR was done while working on [reproducible builds for openSUSE](https://en.opensuse.org/openSUSE:Reproducible_Builds).