### PR TITLE
threads: implement support for unnamed semaphores

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,6 +207,7 @@ LIBC_TOP_HALF_MUSL_SOURCES += \
         thread/pthread_mutexattr_setpshared.c \
         thread/pthread_mutexattr_setrobust.c \
         thread/pthread_mutexattr_settype.c \
+        thread/pthread_testcancel.c \
         thread/sem_destroy.c \
         thread/sem_getvalue.c \
         thread/sem_init.c \

--- a/Makefile
+++ b/Makefile
@@ -192,6 +192,7 @@ LIBC_TOP_HALF_MUSL_SOURCES += \
     $(addprefix $(LIBC_TOP_HALF_MUSL_SRC_DIR)/, \
         thread/__wait.c \
         thread/__timedwait.c \
+        thread/pthread_cleanup_push.c \
         thread/pthread_mutex_consistent.c \
         thread/pthread_mutex_destroy.c \
         thread/pthread_mutex_init.c \
@@ -206,6 +207,13 @@ LIBC_TOP_HALF_MUSL_SOURCES += \
         thread/pthread_mutexattr_setpshared.c \
         thread/pthread_mutexattr_setrobust.c \
         thread/pthread_mutexattr_settype.c \
+        thread/sem_destroy.c \
+        thread/sem_getvalue.c \
+        thread/sem_init.c \
+        thread/sem_post.c \
+        thread/sem_timedwait.c \
+        thread/sem_trywait.c \
+        thread/sem_wait.c \
         thread/pthread_setcancelstate.c \
     )
 endif

--- a/expected/wasm32-wasi/posix/defined-symbols.txt
+++ b/expected/wasm32-wasi/posix/defined-symbols.txt
@@ -187,6 +187,7 @@ __pthread_mutex_trylock
 __pthread_mutex_trylock_owner
 __pthread_mutex_unlock
 __pthread_setcancelstate
+__pthread_testcancel
 __putenv
 __qsort_r
 __rand48_step
@@ -245,6 +246,7 @@ __sysv_signal
 __tan
 __tandf
 __tanl
+__testcancel
 __timedwait
 __timedwait_cp
 __tm_to_secs
@@ -943,6 +945,7 @@ pthread_mutexattr_setpshared
 pthread_mutexattr_setrobust
 pthread_mutexattr_settype
 pthread_setcancelstate
+pthread_testcancel
 putc
 putc_unlocked
 putchar

--- a/expected/wasm32-wasi/posix/defined-symbols.txt
+++ b/expected/wasm32-wasi/posix/defined-symbols.txt
@@ -38,6 +38,8 @@ __ctype_toupper_loc
 __cxa_atexit
 __cxa_finalize
 __des_setkey
+__do_cleanup_pop
+__do_cleanup_push
 __do_des
 __duplocale
 __env_rm_add
@@ -365,6 +367,8 @@ _environ
 _exit
 _flushlbf
 _initialize
+_pthread_cleanup_pop
+_pthread_cleanup_push
 _start
 a64l
 abort
@@ -1007,6 +1011,13 @@ sched_yield
 seed48
 seekdir
 select
+sem_destroy
+sem_getvalue
+sem_init
+sem_post
+sem_timedwait
+sem_trywait
+sem_wait
 send
 setbuf
 setbuffer

--- a/expected/wasm32-wasi/posix/predefined-macros.txt
+++ b/expected/wasm32-wasi/posix/predefined-macros.txt
@@ -1580,6 +1580,8 @@
 #define SEEK_SET __WASI_WHENCE_SET
 #define SEGSIZE 512
 #define SEM_FAILED ((sem_t *)0)
+#define SEM_NSEMS_MAX 256
+#define SEM_VALUE_MAX 0x7fffffff
 #define SERVFAIL ns_r_servfail
 #define SHORTBITS (sizeof(short) * 8)
 #define SHRT_MAX 0x7fff

--- a/libc-top-half/musl/include/limits.h
+++ b/libc-top-half/musl/include/limits.h
@@ -70,7 +70,7 @@
 #define PTHREAD_STACK_MIN 2048
 #define PTHREAD_DESTRUCTOR_ITERATIONS 4
 #endif
-#ifdef __wasilibc_unmodified_upstream /* WASI has no semaphores */
+#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 #define SEM_VALUE_MAX 0x7fffffff
 #define SEM_NSEMS_MAX 256
 #endif

--- a/libc-top-half/musl/src/thread/sem_timedwait.c
+++ b/libc-top-half/musl/src/thread/sem_timedwait.c
@@ -8,7 +8,9 @@ static void cleanup(void *p)
 
 int sem_timedwait(sem_t *restrict sem, const struct timespec *restrict at)
 {
+#ifdef __wasilibc_unmodified_upstream
 	pthread_testcancel();
+#endif	
 
 	if (!sem_trywait(sem)) return 0;
 

--- a/libc-top-half/musl/src/thread/sem_timedwait.c
+++ b/libc-top-half/musl/src/thread/sem_timedwait.c
@@ -8,9 +8,7 @@ static void cleanup(void *p)
 
 int sem_timedwait(sem_t *restrict sem, const struct timespec *restrict at)
 {
-#ifdef __wasilibc_unmodified_upstream
 	pthread_testcancel();
-#endif	
 
 	if (!sem_trywait(sem)) return 0;
 


### PR DESCRIPTION
[POSIX semaphores] come in two forms: named and unnamed. Roughly, named
semaphores use files to implement locking across processes; unnamed
semaphores use a shared memory region to implement locking across
threads in the same process. Since WASI currently has no process concept
(and it is relatively unclear how to map the WASI files as shared
memory), only the unnamed semaphores are supported by this changed. This
means that `sem_open`, `sem_close`, and `sem_unlink` will not available
to programs compiled with a threads-enabled `wasi-libc`.

[POSIX semaphores]: https://man7.org/linux/man-pages/man7/sem_overview.7.html