### PR TITLE
make `__get_tp()` a static function

### DIFF
--- a/expected/wasm32-wasi/posix/defined-symbols.txt
+++ b/expected/wasm32-wasi/posix/defined-symbols.txt
@@ -79,7 +79,6 @@ __fwritable
 __fwritex
 __fwriting
 __get_locale
-__get_tp
 __getdelim
 __getentropy
 __getopt_msg

--- a/libc-top-half/musl/arch/wasm32/pthread_arch.h
+++ b/libc-top-half/musl/arch/wasm32/pthread_arch.h
@@ -1,4 +1,4 @@
-uintptr_t __get_tp(void) {
+static inline uintptr_t __get_tp(void) {
 #if _REENTRANT
   int val;
   __asm__("global.get __wasilibc_pthread_self\n"


### PR DESCRIPTION
I'm not sure if the function really has to be exported. If so, we should probably move it to a separate compilation unit, otherwise it will be defined multiple times (e.g. in `strerror.o` and `__lctrans.o`) causing linker errors. However, I don't see a reason (at least for now) to export this function, therefore making it static in this PR.