### PR TITLE
Add a check to command modules to ensure that they're only started once.

### DIFF
--- a/libc-bottom-half/crt/crt1-command.c
+++ b/libc-bottom-half/crt/crt1-command.c
@@ -3,8 +3,18 @@ extern void __wasm_call_ctors(void);
 extern int __main_void(void);
 extern void __wasm_call_dtors(void);
 
+// Commands should only be called once per instance. This simple check ensures
+// that the `_start` function isn't started more than once.
+static volatile int started = 0;
+
 __attribute__((export_name("_start")))
 void _start(void) {
+    // Don't allow the program to be called multiple times.
+    if (started != 0) {
+	__builtin_trap();
+    }
+    started = 0;
+
     // The linker synthesizes this to call constructors.
     __wasm_call_ctors();
 

--- a/libc-bottom-half/crt/crt1-command.c
+++ b/libc-bottom-half/crt/crt1-command.c
@@ -13,7 +13,7 @@ void _start(void) {
     if (started != 0) {
 	__builtin_trap();
     }
-    started = 0;
+    started = 1;
 
     // The linker synthesizes this to call constructors.
     __wasm_call_ctors();


### PR DESCRIPTION
Wasm command modules should only be called once per instance, because the programming model doesn't leave linear memory in a reusable state when the program exits. As use cases arise for loading wasm modules in environments that want to treat them like reactors, add a safety check to ensure that command modules are used according to their expectations.