### PR TITLE
Fix missing errno assignments.

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/dirent/fdopendir.c
+++ b/libc-bottom-half/cloudlibc/src/libc/dirent/fdopendir.c
@@ -29,6 +29,7 @@ DIR *fdopendir(int fd) {
   if (error != 0) {
     free(dirp->buffer);
     free(dirp);
+    errno = error;
     return NULL;
   }
 

--- a/libc-bottom-half/cloudlibc/src/libc/fcntl/openat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/fcntl/openat.c
@@ -73,6 +73,7 @@ int __wasilibc_nocwd_openat_nomode(int fd, const char *path, int oflag) {
                                  fs_rights_base, fs_rights_inheriting, fs_flags,
                                  &newfd);
   if (error != 0) {
+    errno = error;
     return -1;
   }
   return newfd;

--- a/libc-bottom-half/cloudlibc/src/libc/stdio/renameat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/stdio/renameat.c
@@ -10,6 +10,7 @@
 int __wasilibc_nocwd_renameat(int oldfd, const char *old, int newfd, const char *new) {
   __wasi_errno_t error = __wasi_path_rename(oldfd, old, newfd, new);
   if (error != 0) {
+    errno = error;
     return -1;
   }
   return 0;

--- a/libc-bottom-half/cloudlibc/src/libc/sys/socket/recv.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/socket/recv.c
@@ -33,6 +33,7 @@ ssize_t recv(int socket, void *restrict buffer, size_t length, int flags) {
                                           &ro_datalen,
                                           &ro_flags);
   if (error != 0) {
+    errno = error;
     return -1;
   }
   return ro_datalen;

--- a/libc-bottom-half/cloudlibc/src/libc/sys/socket/send.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/socket/send.c
@@ -25,6 +25,7 @@ ssize_t send(int socket, const void *buffer, size_t length, int flags) {
   size_t so_datalen;
   __wasi_errno_t error = __wasi_sock_send(socket, si_data, si_data_len, si_flags, &so_datalen);
   if (error != 0) {
+    errno = error;
     return -1;
   }
   return so_datalen;

--- a/libc-bottom-half/cloudlibc/src/libc/sys/socket/shutdown.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/socket/shutdown.c
@@ -20,6 +20,7 @@ int shutdown(int socket, int how) {
 
   __wasi_errno_t error = __wasi_sock_shutdown(socket, how);
   if (error != 0) {
+    errno = error;
     return -1;
   }
   return error;

--- a/libc-bottom-half/cloudlibc/src/libc/sys/stat/fstatat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/stat/fstatat.c
@@ -23,6 +23,7 @@ int __wasilibc_nocwd_fstatat(int fd, const char *restrict path, struct stat *res
   __wasi_errno_t error =
       __wasi_path_filestat_get(fd, lookup_flags, path, &internal_stat);
   if (error != 0) {
+    errno = error;
     return -1;
   }
   to_public_stat(&internal_stat, buf);

--- a/libc-bottom-half/cloudlibc/src/libc/sys/stat/mkdirat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/stat/mkdirat.c
@@ -11,6 +11,7 @@
 int __wasilibc_nocwd_mkdirat_nomode(int fd, const char *path) {
   __wasi_errno_t error = __wasi_path_create_directory(fd, path);
   if (error != 0) {
+    errno = error;
     return -1;
   }
   return 0;

--- a/libc-bottom-half/cloudlibc/src/libc/sys/stat/utimensat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/stat/utimensat.c
@@ -18,6 +18,7 @@ int __wasilibc_nocwd_utimensat(int fd, const char *path, const struct timespec t
   __wasi_timestamp_t st_mtim;
   __wasi_fstflags_t flags;
   if (!utimens_get_timestamps(times, &st_atim, &st_mtim, &flags)) {
+    errno = EINVAL;
     return -1;
   }
 
@@ -30,6 +31,7 @@ int __wasilibc_nocwd_utimensat(int fd, const char *path, const struct timespec t
   __wasi_errno_t error =
       __wasi_path_filestat_set_times(fd, lookup_flags, path, st_atim, st_mtim, flags);
   if (error != 0) {
+    errno = error;
     return -1;
   }
   return 0;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/faccessat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/faccessat.c
@@ -22,6 +22,7 @@ int __wasilibc_nocwd_faccessat(int fd, const char *path, int amode, int flag) {
   __wasi_errno_t error =
       __wasi_path_filestat_get(fd, lookup_flags, path, &file);
   if (error != 0) {
+    errno = error;
     return -1;
   }
 

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/linkat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/linkat.c
@@ -17,6 +17,7 @@ int __wasilibc_nocwd_linkat(int fd1, const char *path1, int fd2, const char *pat
   // Perform system call.
   __wasi_errno_t error = __wasi_path_link(fd1, lookup1_flags, path1, fd2, path2);
   if (error != 0) {
+    errno = error;
     return -1;
   }
   return 0;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/readlinkat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/readlinkat.c
@@ -14,6 +14,7 @@ ssize_t __wasilibc_nocwd_readlinkat(int fd, const char *restrict path, char *res
   __wasi_errno_t error = __wasi_path_readlink(fd, path,
                                                       (uint8_t*)buf, bufsize, &bufused);
   if (error != 0) {
+    errno = error;
     return -1;
   }
   return bufused;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/symlinkat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/symlinkat.c
@@ -10,6 +10,7 @@
 int __wasilibc_nocwd_symlinkat(const char *path1, int fd, const char *path2) {
   __wasi_errno_t error = __wasi_path_symlink(path1, fd, path2);
   if (error != 0) {
+    errno = error;
     return -1;
   }
   return 0;

--- a/libc-bottom-half/sources/__wasilibc_rmdirat.c
+++ b/libc-bottom-half/sources/__wasilibc_rmdirat.c
@@ -5,6 +5,7 @@
 int __wasilibc_nocwd___wasilibc_rmdirat(int fd, const char *path) {
     __wasi_errno_t error = __wasi_path_remove_directory(fd, path);
     if (error != 0) {
+        errno = error;
         return -1;
     }
     return 0;


### PR DESCRIPTION
In PR #294 I removed a little too much code; we still need to assign to `errno` in the code in question here.