### PR TITLE
Avoid depending on `max_align_t` in <__struct_sockaddr.h>.

### DIFF
--- a/libc-bottom-half/headers/public/__struct_sockaddr.h
+++ b/libc-bottom-half/headers/public/__struct_sockaddr.h
@@ -7,7 +7,7 @@
 #include <__typedef_sa_family_t.h>
 
 struct sockaddr {
-    _Alignas(max_align_t) sa_family_t sa_family;
+    __attribute__((aligned(__BIGGEST_ALIGNMENT__))) sa_family_t sa_family;
     char sa_data[0];
 };
 


### PR DESCRIPTION
`max_align_t` is not declared in C99 mode, so use an aligned attribute and `__BIGGEST_ALIGNMENT__` instead.

Fixes WebAssembly/wasi-sdk#111.