### PR TITLE
Support threads in the new crt1-command.c ctor check.

### DIFF
--- a/libc-bottom-half/crt/crt1-command.c
+++ b/libc-bottom-half/crt/crt1-command.c
@@ -8,7 +8,7 @@ void _start(void) {
     // Commands should only be called once per instance. This simple check
     // ensures that the `_start` function isn't started more than once.
 #ifdef _REENTRANT
-    static volatile _Atomic int started = 0;
+    static volatile int started = 0;
     if (__sync_val_compare_and_swap(&started, 0, 1) != 0) {
 	__builtin_trap();
     }

--- a/libc-bottom-half/crt/crt1-command.c
+++ b/libc-bottom-half/crt/crt1-command.c
@@ -3,17 +3,22 @@ extern void __wasm_call_ctors(void);
 extern int __main_void(void);
 extern void __wasm_call_dtors(void);
 
-// Commands should only be called once per instance. This simple check ensures
-// that the `_start` function isn't started more than once.
-static volatile int started = 0;
-
 __attribute__((export_name("_start")))
 void _start(void) {
-    // Don't allow the program to be called multiple times.
+    // Commands should only be called once per instance. This simple check
+    // ensures that the `_start` function isn't started more than once.
+#ifdef _REENTRANT
+    static volatile _Atomic int started = 0;
+    if (__sync_val_compare_and_swap(&started, 0, 1) != 0) {
+	__builtin_trap();
+    }
+#else
+    static volatile int started = 0;
     if (started != 0) {
 	__builtin_trap();
     }
     started = 1;
+#endif
 
     // The linker synthesizes this to call constructors.
     __wasm_call_ctors();

--- a/libc-bottom-half/crt/crt1-command.c
+++ b/libc-bottom-half/crt/crt1-command.c
@@ -7,13 +7,12 @@ __attribute__((export_name("_start")))
 void _start(void) {
     // Commands should only be called once per instance. This simple check
     // ensures that the `_start` function isn't started more than once.
-#ifdef _REENTRANT
     static volatile int started = 0;
+#ifdef _REENTRANT
     if (__sync_val_compare_and_swap(&started, 0, 1) != 0) {
 	__builtin_trap();
     }
 #else
-    static volatile int started = 0;
     if (started != 0) {
 	__builtin_trap();
     }

--- a/libc-bottom-half/crt/crt1-command.c
+++ b/libc-bottom-half/crt/crt1-command.c
@@ -10,6 +10,11 @@ __attribute__((export_name("_start")))
 void _start(void) {
     // Commands should only be called once per instance. This simple check
     // ensures that the `_start` function isn't started more than once.
+    //
+    // We use `volatile` here to prevent the store to `started` from being
+    // sunk past any subsequent code, and to prevent any compiler from
+    // optimizing based on the knowledge that `_start` is the program
+    // entrypoint.
 #ifdef _REENTRANT
     static volatile _Atomic int started = 0;
     int expected = 0;

--- a/libc-bottom-half/crt/crt1-command.c
+++ b/libc-bottom-half/crt/crt1-command.c
@@ -1,3 +1,6 @@
+#ifdef _REENTRANT
+#include <stdatomic.h>
+#endif
 #include <wasi/api.h>
 extern void __wasm_call_ctors(void);
 extern int __main_void(void);
@@ -7,12 +10,14 @@ __attribute__((export_name("_start")))
 void _start(void) {
     // Commands should only be called once per instance. This simple check
     // ensures that the `_start` function isn't started more than once.
-    static volatile int started = 0;
 #ifdef _REENTRANT
-    if (__sync_val_compare_and_swap(&started, 0, 1) != 0) {
+    static volatile _Atomic int started = 0;
+    int expected = 0;
+    if (!atomic_compare_exchange_strong(&started, &expected, 1)) {
 	__builtin_trap();
     }
 #else
+    static volatile int started = 0;
     if (started != 0) {
 	__builtin_trap();
     }


### PR DESCRIPTION
Use an atomic compare-and-swap for checking whether constructors have been run, when threads are enabled.