### PR TITLE
Define an `__errno_location` function.

### DIFF
--- a/expected/wasm32-wasi/posix/defined-symbols.txt
+++ b/expected/wasm32-wasi/posix/defined-symbols.txt
@@ -48,6 +48,7 @@ __do_des
 __do_orphaned_stdio_locks
 __duplocale
 __env_rm_add
+__errno_location
 __exp2f_data
 __exp_data
 __expo2

--- a/expected/wasm32-wasi/single/defined-symbols.txt
+++ b/expected/wasm32-wasi/single/defined-symbols.txt
@@ -38,6 +38,7 @@ __des_setkey
 __do_des
 __duplocale
 __env_rm_add
+__errno_location
 __exp2f_data
 __exp_data
 __expo2

--- a/libc-bottom-half/sources/__errno_location.c
+++ b/libc-bottom-half/sources/__errno_location.c
@@ -1,0 +1,5 @@
+#include <errno.h>
+
+int *__errno_location(void) {
+    return &errno;
+}


### PR DESCRIPTION
This function returns the address of `errno`, which makes it easier to access from non-C languages since `errno` is a thread-local variable which requires a special ABI.