### PR TITLE
Install libtinfo5 on ubuntu.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,13 @@ jobs:
       with:
         submodules: true
 
+    - name: Install libtinfo5
+      run: |
+        set -ex
+        sudo apt-get update
+        sudo apt-get install -y libtinfo5
+      if: matrix.os == 'ubuntu-latest'
+
     - name: Install LLVM tools (Windows)
       shell: bash
       run: |


### PR DESCRIPTION
We download LLVM releases built for Ubuntu 18 because LLVM doesn't always have builds for different versions, but the builds we use depend on libtinfo5 which isn't installed on Ubuntu 20 by default. So install it.