### PR TITLE
Add `-fstack-protector` support to wasi-libc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,7 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
         fcntl/creat.c \
         dirent/alphasort.c \
         dirent/versionsort.c \
+        env/__stack_chk_fail.c \
         env/clearenv.c \
         env/getenv.c \
         env/putenv.c \

--- a/expected/wasm32-wasi/posix/defined-symbols.txt
+++ b/expected/wasm32-wasi/posix/defined-symbols.txt
@@ -91,6 +91,7 @@ __getopt_msg
 __gmtime_r
 __hwcap
 __inet_aton
+__init_ssp
 __init_tp
 __intscan
 __invtrigl_R
@@ -236,6 +237,9 @@ __sin
 __sindf
 __sinl
 __small_printf
+__stack_chk_fail
+__stack_chk_fail_local
+__stack_chk_guard
 __stderr_FILE
 __stderr_used
 __stdin_FILE

--- a/expected/wasm32-wasi/single/defined-symbols.txt
+++ b/expected/wasm32-wasi/single/defined-symbols.txt
@@ -81,6 +81,7 @@ __getopt_msg
 __gmtime_r
 __hwcap
 __inet_aton
+__init_ssp
 __intscan
 __invtrigl_R
 __isalnum_l
@@ -193,6 +194,9 @@ __sin
 __sindf
 __sinl
 __small_printf
+__stack_chk_fail
+__stack_chk_fail_local
+__stack_chk_guard
 __stderr_FILE
 __stderr_used
 __stdin_FILE


### PR DESCRIPTION
Inlcude `__stack_chk_fail.c` and initialize `__stack_chk_guard` in ctor.
This allows userland stack smash protection.

```
$ cat main.c
char input[] = "0123456789012345";
int main(void) {
    char buf[8];

    for (char *sp = input, *dp = buf; *sp != '\0'; sp++, dp++) {
        *dp = *sp;
    }
    return 0;
}

$ clang main.c -fstack-protector
$ wasmtime ./a.out
Error: failed to run main module `./a.out`

Caused by:
    0: failed to invoke command default
    1: wasm trap: wasm `unreachable` instruction executed
       wasm backtrace:
           0:  0x258 - <unknown>!__stack_chk_fail
           1:  0x21e - <unknown>!__original_main
           2:   0xca - <unknown>!_start
```
