### PR TITLE
Fix logic errors in the zero-inode path.

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/dirent/readdir.c
+++ b/libc-bottom-half/cloudlibc/src/libc/dirent/readdir.c
@@ -89,11 +89,12 @@ struct dirent *readdir(DIR *dirp) {
     // inode number.
     off_t d_ino = entry.d_ino;
     unsigned char d_type = entry.d_type;
-    if (d_ino == 0) {
+    if (d_ino == 0 && strcmp(dirent->d_name, "..") != 0) {
       struct stat statbuf;
       if (fstatat(dirp->fd, dirent->d_name, &statbuf, AT_SYMLINK_NOFOLLOW) != 0) {
 	if (errno == ENOENT) {
 	  // The file disappeared before we could read it, so skip it.
+	  dirp->buffer_processed += entry_size;
 	  continue;
 	}
         return NULL;


### PR DESCRIPTION
I've now tested the zero-inode path on a Wasm engine specially-modified to have `fd_readdir` set inode numbers to zero. Fix two bugs this turned up:
 - Increment `buffer_processed`, as noticed by @yamt
 - Don't do an `fstatat` on "..", because that references a path outside of the directory, which gets a permission-denied error.