### PR TITLE
__wasi_thread_spawn: stop truncating the return value

### DIFF
--- a/libc-bottom-half/headers/public/wasi/api.h
+++ b/libc-bottom-half/headers/public/wasi/api.h
@@ -2099,7 +2099,7 @@ __wasi_errno_t __wasi_sock_shutdown(
  *
  * @see https://github.com/WebAssembly/wasi-threads/#readme
  */
-__wasi_errno_t __wasi_thread_spawn(
+int32_t __wasi_thread_spawn(
     /**
      * A pointer to an opaque struct to be passed to the module's entry
      * function.

--- a/libc-bottom-half/sources/__wasilibc_real.c
+++ b/libc-bottom-half/sources/__wasilibc_real.c
@@ -665,8 +665,7 @@ int32_t __imported_wasi_thread_spawn(int32_t arg0) __attribute__((
     __import_name__("thread_spawn")
 ));
 
-__wasi_errno_t __wasi_thread_spawn(void* start_arg) {
-	int32_t ret = __imported_wasi_thread_spawn((int32_t) start_arg);
-    return (uint16_t) ret;
+int32_t __wasi_thread_spawn(void* start_arg) {
+    return __imported_wasi_thread_spawn((int32_t) start_arg);
 }
 #endif


### PR DESCRIPTION
as __wasi_errno_t is uint16_t, with the current coding, __pthread_create will never see negative return values from wasi:thread_spawn.
eg. (int)(uint16_t)-1 == 65535.