### PR TITLE
threads: enable access to `pthread_attr_get` functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,6 +200,7 @@ LIBC_TOP_HALF_MUSL_SOURCES += \
         thread/__timedwait.c \
         thread/default_attr.c \
         thread/pthread_attr_destroy.c \
+        thread/pthread_attr_get.c \
         thread/pthread_attr_init.c \
         thread/pthread_attr_setstack.c \
         thread/pthread_attr_setstacksize.c \

--- a/expected/wasm32-wasi/posix/defined-symbols.txt
+++ b/expected/wasm32-wasi/posix/defined-symbols.txt
@@ -972,9 +972,16 @@ program_invocation_short_name
 pselect
 psignal
 pthread_attr_destroy
+pthread_attr_getdetachstate
+pthread_attr_getguardsize
+pthread_attr_getinheritsched
+pthread_attr_getscope
+pthread_attr_getstack
+pthread_attr_getstacksize
 pthread_attr_init
 pthread_attr_setstack
 pthread_attr_setstacksize
+pthread_barrierattr_getpshared
 pthread_cond_broadcast
 pthread_cond_destroy
 pthread_cond_init
@@ -982,6 +989,7 @@ pthread_cond_signal
 pthread_cond_timedwait
 pthread_cond_wait
 pthread_condattr_destroy
+pthread_condattr_getpshared
 pthread_condattr_init
 pthread_condattr_setclock
 pthread_condattr_setpshared
@@ -1000,6 +1008,10 @@ pthread_mutex_timedlock
 pthread_mutex_trylock
 pthread_mutex_unlock
 pthread_mutexattr_destroy
+pthread_mutexattr_getprotocol
+pthread_mutexattr_getpshared
+pthread_mutexattr_getrobust
+pthread_mutexattr_gettype
 pthread_mutexattr_init
 pthread_mutexattr_setprotocol
 pthread_mutexattr_setpshared
@@ -1016,6 +1028,7 @@ pthread_rwlock_trywrlock
 pthread_rwlock_unlock
 pthread_rwlock_wrlock
 pthread_rwlockattr_destroy
+pthread_rwlockattr_getpshared
 pthread_rwlockattr_init
 pthread_rwlockattr_setpshared
 pthread_self

--- a/libc-top-half/musl/src/thread/pthread_attr_get.c
+++ b/libc-top-half/musl/src/thread/pthread_attr_get.c
@@ -17,6 +17,7 @@ int pthread_attr_getinheritsched(const pthread_attr_t *restrict a, int *restrict
 	return 0;
 }
 
+#ifdef __wasilibc_unmodified_upstream /* WASI has no CPU scheduling support. */
 int pthread_attr_getschedparam(const pthread_attr_t *restrict a, struct sched_param *restrict param)
 {
 	param->sched_priority = a->_a_prio;
@@ -28,6 +29,7 @@ int pthread_attr_getschedpolicy(const pthread_attr_t *restrict a, int *restrict 
 	*policy = a->_a_policy;
 	return 0;
 }
+#endif
 
 int pthread_attr_getscope(const pthread_attr_t *restrict a, int *restrict scope)
 {
@@ -56,11 +58,13 @@ int pthread_barrierattr_getpshared(const pthread_barrierattr_t *restrict a, int 
 	return 0;
 }
 
+#ifdef __wasilibc_unmodified_upstream /* Forward declaration of WASI's `__clockid` type. */
 int pthread_condattr_getclock(const pthread_condattr_t *restrict a, clockid_t *restrict clk)
 {
 	*clk = a->__attr & 0x7fffffff;
 	return 0;
 }
+#endif
 
 int pthread_condattr_getpshared(const pthread_condattr_t *restrict a, int *restrict pshared)
 {


### PR DESCRIPTION
The pthreads API exposes functions for querying the attributes of a thread. This change allows these functions to be compiled in the `THREAD_MODEL=posix` build. Some functions are skipped (and documented); they can be added if/when needed. This change is motivated by a `libc-test` test that uses these functions.