### PR TITLE
threads: enable access to `pthread_barrier_*` functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,9 @@ LIBC_TOP_HALF_MUSL_SOURCES += \
         thread/pthread_attr_init.c \
         thread/pthread_attr_setstack.c \
         thread/pthread_attr_setstacksize.c \
+        thread/pthread_barrier_destroy.c \
+        thread/pthread_barrier_init.c \
+        thread/pthread_barrier_wait.c \
         thread/pthread_cleanup_push.c \
         thread/pthread_cond_broadcast.c \
         thread/pthread_cond_destroy.c \

--- a/expected/wasm32-wasi/posix/defined-symbols.txt
+++ b/expected/wasm32-wasi/posix/defined-symbols.txt
@@ -981,6 +981,9 @@ pthread_attr_getstacksize
 pthread_attr_init
 pthread_attr_setstack
 pthread_attr_setstacksize
+pthread_barrier_destroy
+pthread_barrier_init
+pthread_barrier_wait
 pthread_barrierattr_getpshared
 pthread_cond_broadcast
 pthread_cond_destroy

--- a/libc-top-half/musl/src/thread/pthread_barrier_destroy.c
+++ b/libc-top-half/musl/src/thread/pthread_barrier_destroy.c
@@ -9,7 +9,9 @@ int pthread_barrier_destroy(pthread_barrier_t *b)
 			while ((v = b->_b_lock) & INT_MAX)
 				__wait(&b->_b_lock, 0, v, 0);
 		}
+#ifdef __wasilibc_unmodified_upstream /* WASI does not understand processes or locking between them. */
 		__vm_wait();
+#endif
 	}
 	return 0;
 }


### PR DESCRIPTION
In building some `libc-test` tests, I found these functions were not compiled in. This change adds `pthread_barrier_init`, `pthread_barrier_wait`, and `pthread_barrier_destroy` to the `THREAD_MODEL=posix` build. As has been done with previous pthreads PRs, this PR skips any inter-process locking by removing any calls to `__vm_lock` and friends. If in the future WASI gains the "process" concept, then these locations (and the pre-existing ones) will need to be modified.