### PR TITLE
Enable pthread_detach

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -216,6 +216,7 @@ LIBC_TOP_HALF_MUSL_SOURCES += \
         thread/pthread_condattr_setclock.c \
         thread/pthread_condattr_setpshared.c \
         thread/pthread_create.c \
+        thread/pthread_detach.c \
         thread/pthread_getspecific.c \
         thread/pthread_join.c \
         thread/pthread_key_create.c \

--- a/expected/wasm32-wasi/posix/defined-symbols.txt
+++ b/expected/wasm32-wasi/posix/defined-symbols.txt
@@ -994,6 +994,7 @@ pthread_condattr_init
 pthread_condattr_setclock
 pthread_condattr_setpshared
 pthread_create
+pthread_detach
 pthread_exit
 pthread_getspecific
 pthread_join
@@ -1224,6 +1225,7 @@ tgamma
 tgammaf
 tgammal
 thrd_current
+thrd_detach
 thrd_sleep
 time
 timegm


### PR DESCRIPTION
* My application uses it.

* There seems no obviuous reason not to enable it.