### PR TITLE
__init_tp: Initialize TID to non-zero value

### DIFF
--- a/libc-top-half/musl/src/env/__init_tls.c
+++ b/libc-top-half/musl/src/env/__init_tls.c
@@ -70,6 +70,18 @@ int __init_tp(void *p)
 	td->tid = __syscall(SYS_set_tid_address, &__thread_list_lock);
 #else
 	setup_default_stack_size();
+	td->detach_state = DT_JOINABLE;
+	/*
+	 * Initialize the TID to a value which doesn't conflict with
+	 * host-allocated TIDs, so that TID-based locks can work.
+	 *
+	 * Note:
+	 * - Host-allocated TIDs range from 1 to 0x1fffffff. (inclusive)
+	 * - __tl_lock and __lockfile uses TID 0 as "unlocked".
+	 * - __lockfile relies on the fact the most significant two bits
+	 *   of TIDs are 0.
+	 */
+	td->tid = 0x3fffffff;
 #endif
 	td->locale = &libc.global_locale;
 	td->robust_list.head = &td->robust_list.head;


### PR DESCRIPTION
__init_tp: Initialize TID to non-zero value

This fixes TID-based locking used within libc.

Also, initialize detach_state.

cf. https://github.com/WebAssembly/wasi-threads/pull/16
