### PR TITLE
__wait.c: fix a timeout

### DIFF
--- a/libc-top-half/musl/src/thread/__wait.c
+++ b/libc-top-half/musl/src/thread/__wait.c
@@ -48,7 +48,7 @@ void __wait(volatile int *addr, volatile int *waiters, int val, int priv)
 		__syscall(SYS_futex, addr, FUTEX_WAIT|priv, val, 0) != -ENOSYS
 		|| __syscall(SYS_futex, addr, FUTEX_WAIT, val, 0);
 #else
-		__wasilibc_futex_wait(addr, FUTEX_WAIT, val, 0);
+		__wasilibc_futex_wait(addr, FUTEX_WAIT, val, -1);
 #endif
 	}
 	if (waiters) a_dec(waiters);


### PR DESCRIPTION
Note: The typical symptom of this bug is a busy waiting on a lock.

Note: 0 means immediate timeout. a negative value means no timeout.