### PR TITLE
__stdio_exit.c: use normal file locking for now

### DIFF
--- a/libc-top-half/musl/src/stdio/__stdio_exit.c
+++ b/libc-top-half/musl/src/stdio/__stdio_exit.c
@@ -8,9 +8,16 @@ weak_alias(dummy_file, __stderr_used);
 static void close_file(FILE *f)
 {
 	if (!f) return;
+#ifdef __wasilibc_unmodified_upstream
 	FFINALLOCK(f);
+#else
+	FLOCK(f);
+#endif
 	if (f->wpos != f->wbase) f->write(f, 0, 0);
 	if (f->rpos != f->rend) f->seek(f, f->rpos-f->rend, SEEK_CUR);
+#ifndef __wasilibc_unmodified_upstream
+	FUNLOCK(f);
+#endif
 }
 
 void __stdio_exit(void)


### PR DESCRIPTION
Unlike many of platforms with threads/lwps, wasi doesn't have separate api for thread exit and process exit as of writing this. It only has a single `wasi_proc_exit`, which is currently used for both of process exit and thread exit by wasi-libc. Becasue of that, on wasi, exit(3) only terminates the calling thread.

On the other hand, the stdio exit logic uses FFINALLOCK macro, which leaves the file locked. While it's fine on platforms where exit somehow forcibly terminates other threads soon, it can make other threads block on these locks forever on wasi.

Until the situation is cleaned up, this commit makes stdio exit use normal file locking instead of the "final" variant. This change allows other threads to continue running. Hopefully those threads will exit by themselves soon.

cf. https://github.com/WebAssembly/wasi-threads/issues/7