### PR TITLE
Disable pthread_exit for now

### DIFF
--- a/expected/wasm32-wasi-pthread/defined-symbols.txt
+++ b/expected/wasm32-wasi-pthread/defined-symbols.txt
@@ -193,7 +193,6 @@ __progname
 __progname_full
 __pthread_cond_timedwait
 __pthread_create
-__pthread_exit
 __pthread_join
 __pthread_key_create
 __pthread_key_delete
@@ -1002,7 +1001,6 @@ pthread_condattr_setclock
 pthread_condattr_setpshared
 pthread_create
 pthread_detach
-pthread_exit
 pthread_getspecific
 pthread_join
 pthread_key_create

--- a/libc-top-half/musl/include/pthread.h
+++ b/libc-top-half/musl/include/pthread.h
@@ -85,7 +85,9 @@ extern "C" {
 
 int pthread_create(pthread_t *__restrict, const pthread_attr_t *__restrict, void *(*)(void *), void *__restrict);
 int pthread_detach(pthread_t);
+#ifdef __wasilibc_unmodified_upstream
 _Noreturn void pthread_exit(void *);
+#endif
 int pthread_join(pthread_t, void **);
 
 #ifdef __GNUC__

--- a/libc-top-half/musl/src/include/pthread.h
+++ b/libc-top-half/musl/src/include/pthread.h
@@ -7,7 +7,9 @@ hidden int __pthread_once(pthread_once_t *, void (*)(void));
 hidden void __pthread_testcancel(void);
 hidden int __pthread_setcancelstate(int, int *);
 hidden int __pthread_create(pthread_t *restrict, const pthread_attr_t *restrict, void *(*)(void *), void *restrict);
+#ifdef __wasilibc_unmodified_upstream
 hidden _Noreturn void __pthread_exit(void *);
+#endif
 hidden int __pthread_join(pthread_t, void **);
 hidden int __pthread_mutex_lock(pthread_mutex_t *);
 hidden int __pthread_mutex_trylock(pthread_mutex_t *);

--- a/libc-top-half/musl/src/thread/pthread_create.c
+++ b/libc-top-half/musl/src/thread/pthread_create.c
@@ -60,7 +60,11 @@ void __tl_sync(pthread_t td)
 	if (tl_lock_waiters) __wake(&__thread_list_lock, 1, 0);
 }
 
+#ifdef __wasilibc_unmodified_upstream
 _Noreturn void __pthread_exit(void *result)
+#else
+static void __pthread_exit(void *result)
+#endif
 {
 	pthread_t self = __pthread_self();
 	sigset_t set;
@@ -191,7 +195,7 @@ _Noreturn void __pthread_exit(void *result)
 		__tl_unlock();
 		free(self->map_base);
 		// Can't use `exit()` here, because it is too high level
-		for (;;) __wasi_proc_exit(0);
+		return;
 	}
 #endif
 
@@ -212,7 +216,6 @@ _Noreturn void __pthread_exit(void *result)
 	// do it manually here
 	__tl_unlock();
 	// Can't use `exit()` here, because it is too high level
-	for (;;) __wasi_proc_exit(0);
 #endif
 }
 
@@ -272,7 +275,7 @@ static int start_c11(void *p)
 }
 #else
 __attribute__((export_name("wasi_thread_start")))
-_Noreturn void wasi_thread_start(int tid, void *p)
+void wasi_thread_start(int tid, void *p)
 {
 	struct start_args *args = p;
   	__asm__(".globaltype __tls_base, i32\n"
@@ -560,5 +563,7 @@ fail:
 	return EAGAIN;
 }
 
+#ifdef __wasilibc_unmodified_upstream
 weak_alias(__pthread_exit, pthread_exit);
+#endif
 weak_alias(__pthread_create, pthread_create);


### PR DESCRIPTION
The current wasi-threads has no thread-exit functionality. Thus it isn't straightforward to implement pthread_exit without leaking thread context. This commit simply disables pthread_exit for now.

Also, instead of abusing `wasi_proc_exit` for thread exit, make `wasi_thread_start` return.

Note: `wasi_proc_exit` is supposed to terminate all threads in the "process", not only the calling thread.

Note: Depending on the conclusion of the discussion about `wasi_thread_exit`, we might revisit this change later.

References:
https://github.com/WebAssembly/wasi-threads/issues/7 https://github.com/WebAssembly/wasi-threads/pull/17