### PR TITLE
crt1-command.c: always call wasi_proc_exit for _REENTRANT

### DIFF
--- a/libc-bottom-half/crt/crt1-command.c
+++ b/libc-bottom-half/crt/crt1-command.c
@@ -42,6 +42,14 @@ void _start(void) {
     // arguments and calls `__main_argv_argc`.
     int r = __main_void();
 
+    // The following code is basically an inlined copy of exit().
+    // It's mandated by the C standard:
+    //
+    // > If the return type of the main function is a type compatible
+    // > with int, a return from the initial call to the main function
+    // > is equivalent to calling the exit function with the value
+    // > returned by the main function as its argument,
+
     // Call atexit functions, destructors, stdio cleanup, etc.
     __wasm_call_dtors();
 

--- a/libc-bottom-half/crt/crt1-command.c
+++ b/libc-bottom-half/crt/crt1-command.c
@@ -45,9 +45,14 @@ void _start(void) {
     // Call atexit functions, destructors, stdio cleanup, etc.
     __wasm_call_dtors();
 
+#ifdef _REENTRANT
+    // `__wasi_proc_exit` terminates sibling threads.
+    __wasi_proc_exit(r);
+#else
     // If main exited successfully, just return, otherwise call
     // `__wasi_proc_exit`.
     if (r != 0) {
         __wasi_proc_exit(r);
     }
+#endif
 }


### PR DESCRIPTION
Note: a return from main() is an equivalent of exit(), which should terminate sibling threads.
