### PR TITLE
Use `ENOENT` rather than `ENOTCAPABLE` for missing preopens.

### DIFF
--- a/libc-bottom-half/sources/posix.c
+++ b/libc-bottom-half/sources/posix.c
@@ -58,9 +58,9 @@ int __wasilibc_open_nomode(const char *path, int oflag) {
     char *relative_path;
     int dirfd = find_relpath(path, &relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -71,9 +71,9 @@ int access(const char *path, int amode) {
     char *relative_path;
     int dirfd = find_relpath(path, &relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -88,9 +88,9 @@ ssize_t readlink(
     char *relative_path;
     int dirfd = find_relpath(path, &relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -101,9 +101,9 @@ int stat(const char *restrict path, struct stat *restrict buf) {
     char *relative_path;
     int dirfd = find_relpath(path, &relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -114,9 +114,9 @@ int lstat(const char *restrict path, struct stat *restrict buf) {
     char *relative_path;
     int dirfd = find_relpath(path, &relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -127,9 +127,9 @@ int utime(const char *path, const struct utimbuf *times) {
     char *relative_path;
     int dirfd = find_relpath(path, &relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -147,9 +147,9 @@ int utimes(const char *path, const struct timeval times[2]) {
     char *relative_path;
     int dirfd = find_relpath(path, &relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -169,9 +169,9 @@ int unlink(const char *path) {
     char *relative_path;
     int dirfd = find_relpath(path, &relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -185,9 +185,9 @@ int rmdir(const char *path) {
     char *relative_path;
     int dirfd = find_relpath(path, &relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -198,21 +198,21 @@ int remove(const char *path) {
     char *relative_path;
     int dirfd = find_relpath(path, &relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
     // First try to remove it as a file.
     int r = __wasilibc_nocwd___wasilibc_unlinkat(dirfd, relative_path);
-    if (r != 0 && (errno == EISDIR || errno == ENOTCAPABLE)) {
+    if (r != 0 && (errno == EISDIR || errno == ENOENT)) {
         // That failed, but it might be a directory.
         r = __wasilibc_nocwd___wasilibc_rmdirat(dirfd, relative_path);
 
         // If it isn't a directory, we lack capabilities to remove it as a file.
         if (errno == ENOTDIR)
-            errno = ENOTCAPABLE;
+            errno = ENOENT;
     }
     return r;
 }
@@ -221,9 +221,9 @@ int mkdir(const char *path, mode_t mode) {
     char *relative_path;
     int dirfd = find_relpath(path, &relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -234,9 +234,9 @@ DIR *opendir(const char *dirname) {
     char *relative_path;
     int dirfd = find_relpath(dirname, &relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return NULL;
     }
 
@@ -252,9 +252,9 @@ int scandir(
     char *relative_path;
     int dirfd = find_relpath(dir, &relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -265,9 +265,9 @@ int symlink(const char *target, const char *linkpath) {
     char *relative_path;
     int dirfd = find_relpath(linkpath, &relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -287,8 +287,8 @@ int link(const char *old, const char *new) {
                                            new_dirfd, new_relative_path, 0);
     }
 
-    // We couldn't find a preopen for it; indicate that we lack capabilities.
-    errno = ENOTCAPABLE;
+    // We couldn't find a preopen for it; fail as if we can't find the path.
+    errno = ENOENT;
     return -1;
 }
 
@@ -305,8 +305,8 @@ int rename(const char *old, const char *new) {
                                              new_dirfd, new_relative_path);
     }
 
-    // We couldn't find a preopen for it; indicate that we lack capabilities.
-    errno = ENOTCAPABLE;
+    // We couldn't find a preopen for it; fail as if we can't find the path.
+    errno = ENOENT;
     return -1;
 }
 
@@ -317,9 +317,9 @@ __wasilibc_access(const char *path, int mode, int flags)
     char *relative_path;
     int dirfd = find_relpath(path, &relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -334,9 +334,9 @@ __wasilibc_utimens(const char *path, const struct timespec times[2], int flags)
     char *relative_path;
     int dirfd = find_relpath(path, &relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -351,9 +351,9 @@ __wasilibc_stat(const char *__restrict path, struct stat *__restrict st, int fla
     char *relative_path;
     int dirfd = find_relpath(path, &relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -369,9 +369,9 @@ __wasilibc_link(const char *oldpath, const char *newpath, int flags)
     int old_dirfd = find_relpath(oldpath, &old_relative_path);
     int new_dirfd = find_relpath(newpath, &new_relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (old_dirfd == -1 || new_dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -387,9 +387,9 @@ __wasilibc_link_oldat(int olddirfd, const char *oldpath, const char *newpath, in
     char *new_relative_path;
     int new_dirfd = find_relpath(newpath, &new_relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (new_dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -405,9 +405,9 @@ __wasilibc_link_newat(const char *oldpath, int newdirfd, const char *newpath, in
     char *old_relative_path;
     int old_dirfd = find_relpath(oldpath, &old_relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (old_dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -423,9 +423,9 @@ __wasilibc_rename_oldat(int fromdirfd, const char *from, const char *to)
     char *to_relative_path;
     int to_dirfd = find_relpath(to, &to_relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (to_dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 
@@ -439,9 +439,9 @@ __wasilibc_rename_newat(const char *from, int todirfd, const char *to)
     char *from_relative_path;
     int from_dirfd = find_relpath(from, &from_relative_path);
 
-    // If we can't find a preopen for it, indicate that we lack capabilities.
+    // If we can't find a preopen for it, fail as if we can't find the path.
     if (from_dirfd == -1) {
-        errno = ENOTCAPABLE;
+        errno = ENOENT;
         return -1;
     }
 


### PR DESCRIPTION
When a user calls `open` with a path that does not have a corresponding preopen, set errno to `ENOENT` rather than `ENOTCAPABLE`. This conceptually represents an attempt to open a path which has not been provided within the sandbox, so it's more accurately represented as "not present" rather than "insufficient capabilities".

Also, this is one step in migrating away from having `ENOTCAPABLE` as an error code. It came from CloudABI, but it isn't in POSIX and portable application code isn't expecting it.