### PR TITLE
Use a separate OBJDIR for each TARGET_TRIPLE

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ MALLOC_IMPL ?= dlmalloc
 # yes or no
 BUILD_LIBC_TOP_HALF ?= yes
 # The directory where we will store intermediate artifacts.
-OBJDIR ?= $(CURDIR)/build
+OBJDIR ?= $(CURDIR)/build/$(TARGET_TRIPLE)
 
 # When the length is no larger than this threshold, we consider the
 # overhead of bulk memory opcodes to outweigh the performance benefit,


### PR DESCRIPTION
To make it easier to create a sysroot with both triples.

Eg.
```
make -j4 CC=/opt/wasi-sdk-16.0/bin/clang
make -j4 CC=/opt/wasi-sdk-16.0/bin/clang THREAD_MODEL=posix
```