### PR TITLE
Enable pthread_equal function definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,6 +227,7 @@ LIBC_TOP_HALF_MUSL_SOURCES += \
         thread/pthread_condattr_setpshared.c \
         thread/pthread_create.c \
         thread/pthread_detach.c \
+        thread/pthread_equal.c \
         thread/pthread_getspecific.c \
         thread/pthread_join.c \
         thread/pthread_key_create.c \

--- a/expected/wasm32-wasi-pthread/defined-symbols.txt
+++ b/expected/wasm32-wasi-pthread/defined-symbols.txt
@@ -1001,6 +1001,7 @@ pthread_condattr_setclock
 pthread_condattr_setpshared
 pthread_create
 pthread_detach
+pthread_equal
 pthread_getspecific
 pthread_join
 pthread_key_create
@@ -1231,6 +1232,7 @@ tgammaf
 tgammal
 thrd_current
 thrd_detach
+thrd_equal
 thrd_sleep
 time
 timegm


### PR DESCRIPTION
The `pthread_equal` function definition is needed for C++ applications