### PR TITLE
Use __BIGGEST_ALIGNMENT__ instead of max_align_t

### DIFF
--- a/libc-bottom-half/headers/public/__struct_sockaddr.h
+++ b/libc-bottom-half/headers/public/__struct_sockaddr.h
@@ -1,9 +1,6 @@
 #ifndef __wasilibc___struct_sockaddr_h
 #define __wasilibc___struct_sockaddr_h
 
-#define __need_STDDEF_H_misc
-#include <stddef.h>
-
 #include <__typedef_sa_family_t.h>
 
 struct sockaddr {

--- a/libc-bottom-half/headers/public/__struct_sockaddr_in.h
+++ b/libc-bottom-half/headers/public/__struct_sockaddr_in.h
@@ -1,15 +1,12 @@
 #ifndef __wasilibc___struct_sockaddr_in_h
 #define __wasilibc___struct_sockaddr_in_h
 
-#define __need_STDDEF_H_misc
-#include <stddef.h>
-
 #include <__typedef_sa_family_t.h>
 #include <__typedef_in_port_t.h>
 #include <__struct_in_addr.h>
 
 struct sockaddr_in {
-    _Alignas(max_align_t) sa_family_t sin_family;
+    __attribute__((aligned(__BIGGEST_ALIGNMENT__))) sa_family_t sin_family;
     in_port_t sin_port;
     struct in_addr sin_addr;
 };

--- a/libc-bottom-half/headers/public/__struct_sockaddr_in6.h
+++ b/libc-bottom-half/headers/public/__struct_sockaddr_in6.h
@@ -1,15 +1,12 @@
 #ifndef __wasilibc___struct_sockaddr_in6_h
 #define __wasilibc___struct_sockaddr_in6_h
 
-#define __need_STDDEF_H_misc
-#include <stddef.h>
-
 #include <__typedef_sa_family_t.h>
 #include <__typedef_in_port_t.h>
 #include <__struct_in6_addr.h>
 
 struct sockaddr_in6 {
-    _Alignas(max_align_t) sa_family_t sin6_family;
+    __attribute__((aligned(__BIGGEST_ALIGNMENT__))) sa_family_t sin6_family;
     in_port_t sin6_port;
     unsigned sin6_flowinfo;
     struct in6_addr sin6_addr;

--- a/libc-bottom-half/headers/public/__struct_sockaddr_storage.h
+++ b/libc-bottom-half/headers/public/__struct_sockaddr_storage.h
@@ -1,13 +1,10 @@
 #ifndef __wasilibc___struct_sockaddr_storage_h
 #define __wasilibc___struct_sockaddr_storage_h
 
-#define __need_STDDEF_H_misc
-#include <stddef.h>
-
 #include <__typedef_sa_family_t.h>
 
 struct sockaddr_storage {
-    _Alignas(max_align_t) sa_family_t ss_family;
+    __attribute__((aligned(__BIGGEST_ALIGNMENT__))) sa_family_t ss_family;
     char __ss_data[32];
 };
 

--- a/libc-bottom-half/headers/public/__struct_sockaddr_un.h
+++ b/libc-bottom-half/headers/public/__struct_sockaddr_un.h
@@ -1,13 +1,10 @@
 #ifndef __wasilibc___struct_sockaddr_un_h
 #define __wasilibc___struct_sockaddr_un_h
 
-#define __need_STDDEF_H_misc
-#include <stddef.h>
-
 #include <__typedef_sa_family_t.h>
 
 struct sockaddr_un {
-    _Alignas(max_align_t) sa_family_t sun_family;
+    __attribute__((aligned(__BIGGEST_ALIGNMENT__))) sa_family_t sun_family;
 };
 
 #endif


### PR DESCRIPTION
Also, remove no longer necessary __need_STDDEF_H_misc stuff.

References:
https://github.com/WebAssembly/wasi-libc/pull/335
https://github.com/WebAssembly/wasi-sdk/issues/111 https://github.com/llvm/llvm-project/blob/2e999b7dd1934a44d38c3a753460f1e5a217e9a5/clang/lib/Headers/stddef.h#L106-L113