### PR TITLE
Don't use sbrk(0) to determine the initial heap size

### DIFF
--- a/dlmalloc/src/malloc.c
+++ b/dlmalloc/src/malloc.c
@@ -5222,6 +5222,9 @@ static void try_init_allocator(void) {
   /* Check that it is a first-time initialization. */
   assert(!is_initialized(gm));
 
+  /* Initialize mstate. */
+  ensure_initialization();
+
   char *base = &__heap_base;
   // Try to use the linker pseudo-symbol `__heap_end` for the initial size of
   // the heap, but if that's not defined due to LLVM being too old perhaps then
@@ -5247,9 +5250,6 @@ static void try_init_allocator(void) {
   if (initial_heap_size <= MIN_CHUNK_SIZE + TOP_FOOT_SIZE + MALLOC_ALIGNMENT) {
     return;
   }
-
-  /* Initialize mstate. */
-  ensure_initialization();
 
   /* Initialize the dlmalloc internal state. */
   gm->least_addr = base;

--- a/dlmalloc/src/malloc.c
+++ b/dlmalloc/src/malloc.c
@@ -5238,10 +5238,10 @@ static void try_init_allocator(void) {
   // correct if the we're the first to try to grow the heap. If the heap has
   // grown elsewhere, such as a different allocator in place, then this would
   // incorrectly claim such memroy as our own.
-  char *init = &__heap_end;
-  if (init == NULL)
-    init = (char*) (((size_t) base + PAGESIZE - 1) & ~(PAGESIZE - 1));
-  int initial_heap_size = init - base;
+  char *end = &__heap_end;
+  if (end == NULL)
+    end = (char*) page_align((size_t) base);
+  size_t initial_heap_size = end - base;
 
   /* Check that initial heap is long enough to serve a minimal allocation request. */
   if (initial_heap_size <= MIN_CHUNK_SIZE + TOP_FOOT_SIZE + MALLOC_ALIGNMENT) {


### PR DESCRIPTION
This commit changes the `try_init_allocator` function as part of dlmalloc to not use `sbrk(0)` to determine the initial heap size. The purpose of this function is to use the extra memory at the end of linear memory for the initial allocation heap before `memory.grow` is used to allocate more memory. To learn the extent of this region the code previously would use `sbrk(0)` to find the current size of linear memory. This does not work, however, when other systems have called `memory.grow` before this function is called. For example if another allocator is used or if another component of a wasm binary grows memory for its own purposes then that memory will be incorrectly claimed to be owned by dlmalloc.

Instead this commit rounds up the `__heap_base` address to the nearest page size, since that must be allocatable. Otherwise anything above this rounded address is assumed to be used by something else, even if it's addressable.