### PR TITLE
threads: add `pthread_attr_setdetachstate`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,7 @@ LIBC_TOP_HALF_MUSL_SOURCES += \
         thread/pthread_attr_get.c \
         thread/pthread_attr_init.c \
         thread/pthread_attr_setstack.c \
+        thread/pthread_attr_setdetachstate.c \
         thread/pthread_attr_setstacksize.c \
         thread/pthread_barrier_destroy.c \
         thread/pthread_barrier_init.c \

--- a/expected/wasm32-wasi-pthread/defined-symbols.txt
+++ b/expected/wasm32-wasi-pthread/defined-symbols.txt
@@ -983,6 +983,7 @@ pthread_attr_getscope
 pthread_attr_getstack
 pthread_attr_getstacksize
 pthread_attr_init
+pthread_attr_setdetachstate
 pthread_attr_setstack
 pthread_attr_setstacksize
 pthread_barrier_destroy


### PR DESCRIPTION
This API may not make a lot of sense in a WebAssembly world but it seemed helpful to include it, even if it doesn't have much effect.