### PR TITLE
threads: enable more of `pthread_mutexattr_setprotocol`

### DIFF
--- a/libc-top-half/musl/src/thread/pthread_mutexattr_setprotocol.c
+++ b/libc-top-half/musl/src/thread/pthread_mutexattr_setprotocol.c
@@ -11,19 +11,19 @@ int pthread_mutexattr_setprotocol(pthread_mutexattr_t *a, int protocol)
 		a->__attr &= ~8;
 		return 0;
 	case PTHREAD_PRIO_INHERIT:
-#ifdef __wasilibc_unmodified_upstream
 		r = check_pi_result;
 		if (r < 0) {
 			volatile int lk = 0;
+#ifdef __wasilibc_unmodified_upstream
 			r = -__syscall(SYS_futex, &lk, FUTEX_LOCK_PI, 0, 0);
+#else
+			r = __wasilibc_futex_wait(&lk, FUTEX_LOCK_PI, 0, 0);
+#endif
 			a_store(&check_pi_result, r);
 		}
 		if (r) return r;
 		a->__attr |= 8;
 		return 0;
-#else
-		return ENOTSUP;
-#endif
 	case PTHREAD_PRIO_PROTECT:
 		return ENOTSUP;
 	default:


### PR DESCRIPTION
While using wasi-threads with wasi-libc, I found a use of this branch of the code. Adding in the WASI version of `futex_wait` seems to fix things.