### PR TITLE
Partially revert "Don't use sbrk(0) to determine the initial heap size"

### DIFF
--- a/dlmalloc/src/malloc.c
+++ b/dlmalloc/src/malloc.c
@@ -5227,23 +5227,12 @@ static void try_init_allocator(void) {
 
   char *base = &__heap_base;
   // Try to use the linker pseudo-symbol `__heap_end` for the initial size of
-  // the heap, but if that's not defined due to LLVM being too old perhaps then
-  // round up `base` to the nearest `PAGESIZE`. The initial size of linear
-  // memory will be at least the heap base to this page boundary, and it's then
-  // assumed that the initial linear memory image was truncated at that point.
-  // While this reflects the default behavior of `wasm-ld` it is also possible
-  // for users to craft larger linear memories by passing options to extend
-  // beyond this threshold. In this situation the memory will not be used for
-  // dlmalloc.
-  //
-  // Note that `sbrk(0)`, or in dlmalloc-ese `CALL_MORECORE(0)`, is specifically
-  // not used here. That captures the current size of the heap but is only
-  // correct if the we're the first to try to grow the heap. If the heap has
-  // grown elsewhere, such as a different allocator in place, then this would
-  // incorrectly claim such memroy as our own.
+  // the heap, but if that's not defined due to LLVM being too old then
+  // fall back to assuming the heap extends to end of linear memory.
+  // (`CALL_MORECORE(0)`)
   char *end = &__heap_end;
   if (end == NULL)
-    end = (char*) page_align((size_t) base);
+    end = (char *)CALL_MORECORE(0);
   size_t initial_heap_size = end - base;
 
   /* Check that initial heap is long enough to serve a minimal allocation request. */


### PR DESCRIPTION
While the problem it addressed (`memory.grow` use outside of malloc) is real, it has been broken for long in this implementation. IMO, the fix doesn't warrant breaking other working use cases, (Pre-populating heap with `--init-memory`) especially when a better solution (`__heap_end`) is on the horizon.