### PR TITLE
Rename thread_spawn import

### DIFF
--- a/libc-bottom-half/sources/__wasilibc_real.c
+++ b/libc-bottom-half/sources/__wasilibc_real.c
@@ -662,7 +662,7 @@ __wasi_errno_t __wasi_sock_shutdown(
 #ifdef _REENTRANT
 int32_t __imported_wasi_thread_spawn(int32_t arg0) __attribute__((
     __import_module__("wasi"),
-    __import_name__("thread_spawn")
+    __import_name__("thread-spawn")
 ));
 
 int32_t __wasi_thread_spawn(void* start_arg) {


### PR DESCRIPTION
Following the wit-defined ABI:
https://github.com/WebAssembly/wasi-threads/pull/26