### PR TITLE
fix: disable bulk memory feature when `BULK_MEMORY_THRESHOLD` is `UINT32_MAX`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -503,10 +503,12 @@ $(MUSL_PRINTSCAN_NO_FLOATING_POINT_OBJS): CFLAGS += \
 	    -D__wasilibc_printscan_no_floating_point \
 	    -D__wasilibc_printscan_floating_point_support_option="\"remove -lc-printscan-no-floating-point from the link command\""
 
+ifneq (${BULK_MEMORY_THRESHOLD},UINT32_MAX)
 # TODO: apply -mbulk-memory globally, once
 # https://github.com/llvm/llvm-project/issues/52618 is resolved
 $(BULK_MEMORY_OBJS): CFLAGS += \
         -mbulk-memory
+endif
 
 $(BULK_MEMORY_OBJS): CFLAGS += \
         -DBULK_MEMORY_THRESHOLD=$(BULK_MEMORY_THRESHOLD)


### PR DESCRIPTION
I want to run c++ code in some platform which does not support bulk memory instruction.

If env `BULK_MEMORY_THRESHOLD` is `UINT32_MAX` which means we don't want to use bulk memory instruction. So maybe it is reasonable to disable this feature in this situation.