### PR TITLE
threads: enable `PTHREAD_{MUTEX,RWLOCK,COND}_INITIALIZER`

### DIFF
--- a/libc-top-half/musl/include/pthread.h
+++ b/libc-top-half/musl/include/pthread.h
@@ -55,15 +55,9 @@ extern "C" {
 #define PTHREAD_PROCESS_SHARED 1
 
 
-#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 #define PTHREAD_MUTEX_INITIALIZER {{{0}}}
 #define PTHREAD_RWLOCK_INITIALIZER {{{0}}}
 #define PTHREAD_COND_INITIALIZER {{{0}}}
-#else
-#define PTHREAD_MUTEX_INITIALIZER 0
-#define PTHREAD_RWLOCK_INITIALIZER 0
-#define PTHREAD_COND_INITIALIZER 0
-#endif
 #define PTHREAD_ONCE_INIT 0
 
 


### PR DESCRIPTION
It looks like `defined(_REENTRANT)` was added [here](https://github.com/WebAssembly/wasi-libc/commit/e5f14be38362f1ab83302895a6e74b2ffd0e2302#diff-5fd85e51ddf267812e2334651dea03b419c9d7a981d33e0d43a9f72e64bb96db) and it was just to mark these as modifiied. (@sunfishcode would know for sure.)

With this change I can build libcxxabi, libcxx, and boost with threads enabled, and link a few binaries (that do not spawn threads, but use mutexes).