### PR TITLE
Use sorted inputs in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -488,13 +488,13 @@ $(SYSROOT_LIB)/libwasi-emulated-signal.a: $(LIBWASI_EMULATED_SIGNAL_OBJS) $(LIBW
 %.a:
 	@mkdir -p "$(@D)"
 	# On Windows, the commandline for the ar invocation got too long, so it needs to be split up.
-	$(AR) crs $@ $(wordlist 1, 199, $^)
-	$(AR) crs $@ $(wordlist 200, 399, $^)
-	$(AR) crs $@ $(wordlist 400, 599, $^)
-	$(AR) crs $@ $(wordlist 600, 799, $^)
+	$(AR) crs $@ $(wordlist 1, 199, $(sort $^))
+	$(AR) crs $@ $(wordlist 200, 399, $(sort $^))
+	$(AR) crs $@ $(wordlist 400, 599, $(sort $^))
+	$(AR) crs $@ $(wordlist 600, 799, $(sort $^))
 	# This might eventually overflow again, but at least it'll do so in a loud way instead of
 	# silently dropping the tail.
-	$(AR) crs $@ $(wordlist 800, 100000, $^)
+	$(AR) crs $@ $(wordlist 800, 100000, $(sort $^))
 
 $(MUSL_PRINTSCAN_OBJS): CFLAGS += \
 	    -D__wasilibc_printscan_no_long_double \


### PR DESCRIPTION
This makes builds reproducible (see #398).

I have tried in two separate Debian testing machines, with different hardware specs (in particular, I think the number of cores can influence the output), the repository cloned in `/tmp` and LLVM/Clang provided by Debian (currently, 14.0.6).

I had this hash in both machines:

```
4490208a83e0da0d4e4cf88a1b15b3e3704e9f45ae79a1339d19603ce3f00ade  sysroot/lib/wasm32-wasi/libc.a
```

@abrown