### PR TITLE
Acquire the global lock before initializing malloc

### DIFF
--- a/dlmalloc/src/malloc.c
+++ b/dlmalloc/src/malloc.c
@@ -4593,14 +4593,14 @@ void* dlmalloc(size_t bytes) {
   ensure_initialization(); /* initialize in sys_alloc if not using locks */
 #endif
 
+  if (!PREACTION(gm)) {
 #if __wasilibc_unmodified_upstream // Try to initialize the allocator.
 #else
-  if (!is_initialized(gm)) {
-    try_init_allocator();
-  }
+    if (!is_initialized(gm)) {
+      try_init_allocator();
+    }
 #endif
 
-  if (!PREACTION(gm)) {
     void* mem;
     size_t nb;
     if (bytes <= MAX_SMALL_REQUEST) {


### PR DESCRIPTION
In a multi-threaded execution we need to make sure that only exactly one thread initializes malloc. The function try_init_allocator() can't easily be made thread-safe, so just move the call to try_init_allocator() inside the block that holds the lock.