### PR TITLE
Change import for thread-spawn from wasi to wasi_snapshot_preview1

### DIFF
--- a/libc-bottom-half/sources/__wasilibc_real.c
+++ b/libc-bottom-half/sources/__wasilibc_real.c
@@ -661,7 +661,7 @@ __wasi_errno_t __wasi_sock_shutdown(
 
 #ifdef _REENTRANT
 int32_t __imported_wasi_thread_spawn(int32_t arg0) __attribute__((
-    __import_module__("wasi"),
+    __import_module__("wasi_snapshot_preview1"),
     __import_name__("thread-spawn")
 ));
 


### PR DESCRIPTION
This PR changes the import module for `thread-spawn` from `wasi` to `wasi_snapshot_preview1`  .  I believe this is correct looking at the spec header file:

https://github.com/WebAssembly/wasi-libc/blob/a6f871343313220b76009827ed0153586361c0d5/libc-bottom-half/headers/public/wasi/api.h#L2102

(The actual API documentation is a 404 : https://github.com/WebAssembly/WASI/blob/main/phases/snapshot/docs.md)

Also, it you see how hosts are implementing this, some at least have it in `wasi_snapshot_preview1`

https://github.com/wasmerio/wasmer/blob/36b077d34b47ec735e5bac7aebcf2878e30135e7/lib/wasi/src/lib.rs#L398
