### PR TITLE
Add definitions for PF_INET, PF_INET6 and PF_UNSPEC

### DIFF
--- a/expected/wasm32-wasi-threads/predefined-macros.txt
+++ b/expected/wasm32-wasi-threads/predefined-macros.txt
@@ -33,10 +33,10 @@
 #define ADJ_TAI 0x0080
 #define ADJ_TICK 0x4000
 #define ADJ_TIMECONST 0x0020
-#define AF_INET 1
-#define AF_INET6 2
+#define AF_INET PF_INET
+#define AF_INET6 PF_INET6
 #define AF_UNIX 3
-#define AF_UNSPEC 0
+#define AF_UNSPEC PF_UNSPEC
 #define ALT_DIGITS 0x2002F
 #define AM_STR 0x20026
 #define ANYMARK 0x01
@@ -1315,6 +1315,9 @@
 #define PAGE_SIZE PAGESIZE
 #define PATH_MAX 4096
 #define PDP_ENDIAN __PDP_ENDIAN
+#define PF_INET 1
+#define PF_INET6 2
+#define PF_UNSPEC 0
 #define PM_STR 0x20027
 #define POLLERR 0x1000
 #define POLLHUP 0x2000

--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -33,10 +33,10 @@
 #define ADJ_TAI 0x0080
 #define ADJ_TICK 0x4000
 #define ADJ_TIMECONST 0x0020
-#define AF_INET 1
-#define AF_INET6 2
+#define AF_INET PF_INET
+#define AF_INET6 PF_INET6
 #define AF_UNIX 3
-#define AF_UNSPEC 0
+#define AF_UNSPEC PF_UNSPEC
 #define ALT_DIGITS 0x2002F
 #define AM_STR 0x20026
 #define ANYMARK 0x01
@@ -1315,6 +1315,9 @@
 #define PAGE_SIZE PAGESIZE
 #define PATH_MAX 4096
 #define PDP_ENDIAN __PDP_ENDIAN
+#define PF_INET 1
+#define PF_INET6 2
+#define PF_UNSPEC 0
 #define PM_STR 0x20027
 #define POLLERR 0x1000
 #define POLLHUP 0x2000

--- a/libc-bottom-half/headers/public/__header_sys_socket.h
+++ b/libc-bottom-half/headers/public/__header_sys_socket.h
@@ -25,9 +25,13 @@
 
 #define SO_TYPE 3
 
-#define AF_UNSPEC 0
-#define AF_INET 1
-#define AF_INET6 2
+#define PF_UNSPEC 0
+#define PF_INET 1
+#define PF_INET6 2
+
+#define AF_UNSPEC PF_UNSPEC
+#define AF_INET PF_INET
+#define AF_INET6 PF_INET6
 #define AF_UNIX 3
 
 #ifdef __cplusplus


### PR DESCRIPTION
Given there are already AF_* definitions, and they are (now) essentially synonyms, we add those definitions to enable compilation of code that already use PF_* macros.