### PR TITLE
Fix recursive mutex

### DIFF
--- a/libc-top-half/musl/src/thread/pthread_mutex_trylock.c
+++ b/libc-top-half/musl/src/thread/pthread_mutex_trylock.c
@@ -21,7 +21,9 @@ int __pthread_mutex_trylock_owner(pthread_mutex_t *m)
 			return 0;
 		}
 	}
+#ifdef __wasilibc_unmodified_upstream
 	if (own == 0x3fffffff) return ENOTRECOVERABLE;
+#endif
 	if (own || (old && !(type & 4))) return EBUSY;
 
 	if (type & 128) {


### PR DESCRIPTION
the robust mutex logic in musl seems to assume that the bit 29 of TIDs is always zero for some reasons.

from https://git.musl-libc.org/cgit/musl/commit/?id=099b89d3840c30d7dd962e18668c2e6d39f0c626
> note that the kernel ABI also reserves bit 29
> not to appear in any tid,

i'm not sure if the assumption is true or not, given that FUTEX_TID_MASK is 0x3fffffff.

anyway, when using non-default type of mutex like recursive mutex, it causes problems as we actually use TID 0x3fffffff for the main thread.

as we don't support robust mutex anyway, this commit simply comments out the problematic condition.

fixes: https://github.com/bytecodealliance/wasm-micro-runtime/issues/2466