### PR TITLE
ifdef out pthread_cancel

### DIFF
--- a/libc-top-half/musl/include/pthread.h
+++ b/libc-top-half/musl/include/pthread.h
@@ -97,7 +97,9 @@ int pthread_equal(pthread_t, pthread_t);
 int pthread_setcancelstate(int, int *);
 int pthread_setcanceltype(int, int *);
 void pthread_testcancel(void);
+#ifdef __wasilibc_unmodified_upstream /* WASI has no cancellation support. */
 int pthread_cancel(pthread_t);
+#endif
 
 #ifdef __wasilibc_unmodified_upstream /* WASI has no CPU scheduling support. */
 int pthread_getschedparam(pthread_t, int *__restrict, struct sched_param *__restrict);


### PR DESCRIPTION
as we don't actually support thread cancellation.

note: currently we don't build pthread_cancel.c either. this commit just disables it in our header too to make users notice that it isn't provided a bit earlier.

should we disable other cancellation related functions like pthread_testcancel? maybe. but they are harmless to ignore.