### PR TITLE
Adjust Makefile for LLVM trunk (18) as of 2023-12-07

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -760,6 +760,7 @@ check-symbols: startup_files libc
 	@# TODO: Filter out __GCC_HAVE_SYNC_COMPARE_AND_SWAP_* that are new to clang 16.
 	@# TODO: Filter out __FPCLASS_* that are new to clang 17.
 	@# TODO: Filter out __FLT128_* that are new to clang 18.
+	@# TODO: Filter out __MEMORY_SCOPE_* that are new to clang 18.
 	@# TODO: clang defined __FLT_EVAL_METHOD__ until clang 15, so we force-undefine it
 	@# for older versions.
 	@# TODO: Undefine __wasm_mutable_globals__ and __wasm_sign_ext__, that are new to
@@ -793,6 +794,7 @@ check-symbols: startup_files libc
 	    | grep -v '^#define __GCC_HAVE_SYNC_COMPARE_AND_SWAP_\(1\|2\|4\|8\)' \
 	    | grep -v '^#define __FPCLASS_' \
 	    | grep -v '^#define __FLT128_' \
+	    | grep -v '^#define __MEMORY_SCOPE_' \
 	    | grep -v '^#define NDEBUG' \
 	    | grep -v '^#define __OPTIMIZE__' \
 	    | grep -v '^#define assert' \


### PR DESCRIPTION
https://github.com/llvm/llvm-project/commit/4e80bc7d716b1f2344ffd7ad109413bfe5390879 added __MEMORY_SCOPE_* macros.