### PR TITLE
Remove trailing backtick in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ string, environment variables, program startup, and many other APIs.
 `wasi-libc` is sufficiently stable and usable for many purposes, as most of the
 POSIX-compatible APIs are stable, though it is continuing to evolve to better
 align with wasm and WASI. For example, pthread support is experimentally
-provided via the [wasi-threads] proposal.`
+provided via the [wasi-threads] proposal.
 
 [wasi-threads]: https://github.com/WebAssembly/wasi-threads
 


### PR DESCRIPTION
Updates README.md with trailing backtick removed.