### PR TITLE
add stubs for `statvfs`, `chmod`, etc.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -425,7 +425,6 @@ MUSL_OMIT_HEADERS += \
     "bits/shm.h" "bits/msg.h" "bits/ipc.h" "bits/ptrace.h" \
     "bits/statfs.h" \
     "sys/vfs.h" \
-    "sys/statvfs.h" \
     "syslog.h" "sys/syslog.h" \
     "wait.h" "sys/wait.h" \
     "ucontext.h" "sys/ucontext.h" \

--- a/expected/wasm32-wasi-preview2/defined-symbols.txt
+++ b/expected/wasm32-wasi-preview2/defined-symbols.txt
@@ -447,6 +447,7 @@ cexp
 cexpf
 cexpl
 chdir
+chmod
 cimag
 cimagf
 cimagl
@@ -543,6 +544,8 @@ fabs
 fabsf
 fabsl
 faccessat
+fchmod
+fchmodat
 fclose
 fcntl
 fcvt
@@ -637,6 +640,7 @@ fsetpos
 fsetpos64
 fstat
 fstatat
+fstatvfs
 fsync
 ftell
 ftello
@@ -1012,6 +1016,7 @@ srand48
 srandom
 sscanf
 stat
+statvfs
 stderr
 stdin
 stdout

--- a/expected/wasm32-wasi-preview2/include-all.c
+++ b/expected/wasm32-wasi-preview2/include-all.c
@@ -141,6 +141,7 @@
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <sys/statvfs.h>
 #include <sys/stropts.h>
 #include <sys/syscall.h>
 #include <sys/sysinfo.h>

--- a/expected/wasm32-wasi-preview2/predefined-macros.txt
+++ b/expected/wasm32-wasi-preview2/predefined-macros.txt
@@ -181,6 +181,7 @@
 #define DT_FIFO __WASI_FILETYPE_SOCKET_STREAM
 #define DT_LNK __WASI_FILETYPE_SYMBOLIC_LINK
 #define DT_REG __WASI_FILETYPE_REGULAR_FILE
+#define DT_SOCK 20
 #define DT_UNKNOWN __WASI_FILETYPE_UNKNOWN
 #define D_FMT 0x20029
 #define D_T_FMT 0x20028
@@ -1637,6 +1638,18 @@
 #define STRU_F 1
 #define STRU_P 3
 #define STRU_R 2
+#define ST_APPEND 256
+#define ST_IMMUTABLE 512
+#define ST_MANDLOCK 64
+#define ST_NOATIME 1024
+#define ST_NODEV 4
+#define ST_NODIRATIME 2048
+#define ST_NOEXEC 8
+#define ST_NOSUID 2
+#define ST_RDONLY 1
+#define ST_RELATIME 4096
+#define ST_SYNCHRONOUS 16
+#define ST_WRITE 128
 #define SUN_LEN(s) (2+strlen((s)->sun_path))
 #define SUSP 237
 #define SYMLOOP_MAX 40
@@ -1651,7 +1664,7 @@
 #define S_IFBLK (0x6000)
 #define S_IFCHR (0x2000)
 #define S_IFDIR (0x4000)
-#define S_IFIFO (0xc000)
+#define S_IFIFO (0x1000)
 #define S_IFLNK (0xa000)
 #define S_IFMT (S_IFBLK | S_IFCHR | S_IFDIR | S_IFIFO | S_IFLNK | S_IFREG | S_IFSOCK)
 #define S_IFREG (0x8000)
@@ -2018,7 +2031,7 @@
 #define _Complex_I (0.0f+1.0fi)
 #define _DIRENT_H 
 #define _DIRENT_HAVE_D_TYPE 
-#define _DLFCN_H
+#define _DLFCN_H 
 #define _ENDIAN_H 
 #define _ERRNO_H 
 #define _ERR_H 
@@ -2323,6 +2336,7 @@
 #define _SYS_REG_H 
 #define _SYS_SELECT_H 
 #define _SYS_SOCKET_H 
+#define _SYS_STATVFS_H 
 #define _SYS_STAT_H 
 #define _SYS_SYSCALL_H 
 #define _SYS_SYSINFO_H 
@@ -3146,6 +3160,7 @@
 #define fsfilcnt64_t fsfilcnt_t
 #define fstat64 fstat
 #define fstatat64 fstatat
+#define fstatvfs64 fstatvfs
 #define ftello64 ftello
 #define ftruncate64 ftruncate
 #define getdents64 getdents
@@ -3329,6 +3344,7 @@
 #define st_mtime st_mtim.tv_sec
 #define stat64 stat
 #define static_assert _Static_assert
+#define statvfs64 statvfs
 #define stderr (stderr)
 #define stdin (stdin)
 #define stdout (stdout)

--- a/expected/wasm32-wasi-threads/defined-symbols.txt
+++ b/expected/wasm32-wasi-threads/defined-symbols.txt
@@ -511,6 +511,7 @@ cexp
 cexpf
 cexpl
 chdir
+chmod
 cimag
 cimagf
 cimagl
@@ -607,6 +608,8 @@ fabs
 fabsf
 fabsl
 faccessat
+fchmod
+fchmodat
 fclose
 fcntl
 fcvt
@@ -702,6 +705,7 @@ fsetpos
 fsetpos64
 fstat
 fstatat
+fstatvfs
 fsync
 ftell
 ftello
@@ -1162,6 +1166,7 @@ srand48
 srandom
 sscanf
 stat
+statvfs
 stderr
 stdin
 stdout

--- a/expected/wasm32-wasi-threads/include-all.c
+++ b/expected/wasm32-wasi-threads/include-all.c
@@ -142,6 +142,7 @@
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <sys/statvfs.h>
 #include <sys/stropts.h>
 #include <sys/syscall.h>
 #include <sys/sysinfo.h>

--- a/expected/wasm32-wasi-threads/predefined-macros.txt
+++ b/expected/wasm32-wasi-threads/predefined-macros.txt
@@ -181,6 +181,7 @@
 #define DT_FIFO __WASI_FILETYPE_SOCKET_STREAM
 #define DT_LNK __WASI_FILETYPE_SYMBOLIC_LINK
 #define DT_REG __WASI_FILETYPE_REGULAR_FILE
+#define DT_SOCK 20
 #define DT_UNKNOWN __WASI_FILETYPE_UNKNOWN
 #define D_FMT 0x20029
 #define D_T_FMT 0x20028
@@ -1671,6 +1672,18 @@
 #define STRU_F 1
 #define STRU_P 3
 #define STRU_R 2
+#define ST_APPEND 256
+#define ST_IMMUTABLE 512
+#define ST_MANDLOCK 64
+#define ST_NOATIME 1024
+#define ST_NODEV 4
+#define ST_NODIRATIME 2048
+#define ST_NOEXEC 8
+#define ST_NOSUID 2
+#define ST_RDONLY 1
+#define ST_RELATIME 4096
+#define ST_SYNCHRONOUS 16
+#define ST_WRITE 128
 #define SUN_LEN(s) (2+strlen((s)->sun_path))
 #define SUSP 237
 #define SYMLOOP_MAX 40
@@ -1685,7 +1698,7 @@
 #define S_IFBLK (0x6000)
 #define S_IFCHR (0x2000)
 #define S_IFDIR (0x4000)
-#define S_IFIFO (0xc000)
+#define S_IFIFO (0x1000)
 #define S_IFLNK (0xa000)
 #define S_IFMT (S_IFBLK | S_IFCHR | S_IFDIR | S_IFIFO | S_IFLNK | S_IFREG | S_IFSOCK)
 #define S_IFREG (0x8000)
@@ -2052,7 +2065,7 @@
 #define _Complex_I (0.0f+1.0fi)
 #define _DIRENT_H 
 #define _DIRENT_HAVE_D_TYPE 
-#define _DLFCN_H
+#define _DLFCN_H 
 #define _ENDIAN_H 
 #define _ERRNO_H 
 #define _ERR_H 
@@ -2360,6 +2373,7 @@
 #define _SYS_REG_H 
 #define _SYS_SELECT_H 
 #define _SYS_SOCKET_H 
+#define _SYS_STATVFS_H 
 #define _SYS_STAT_H 
 #define _SYS_SYSCALL_H 
 #define _SYS_SYSINFO_H 
@@ -3185,6 +3199,7 @@
 #define fsfilcnt64_t fsfilcnt_t
 #define fstat64 fstat
 #define fstatat64 fstatat
+#define fstatvfs64 fstatvfs
 #define ftello64 ftello
 #define ftruncate64 ftruncate
 #define getdents64 getdents
@@ -3371,6 +3386,7 @@
 #define st_mtime st_mtim.tv_sec
 #define stat64 stat
 #define static_assert _Static_assert
+#define statvfs64 statvfs
 #define stderr (stderr)
 #define stdin (stdin)
 #define stdout (stdout)

--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -447,6 +447,7 @@ cexp
 cexpf
 cexpl
 chdir
+chmod
 cimag
 cimagf
 cimagl
@@ -543,6 +544,8 @@ fabs
 fabsf
 fabsl
 faccessat
+fchmod
+fchmodat
 fclose
 fcntl
 fcvt
@@ -637,6 +640,7 @@ fsetpos
 fsetpos64
 fstat
 fstatat
+fstatvfs
 fsync
 ftell
 ftello
@@ -1012,6 +1016,7 @@ srand48
 srandom
 sscanf
 stat
+statvfs
 stderr
 stdin
 stdout

--- a/expected/wasm32-wasi/include-all.c
+++ b/expected/wasm32-wasi/include-all.c
@@ -141,6 +141,7 @@
 #include <sys/select.h>
 #include <sys/socket.h>
 #include <sys/stat.h>
+#include <sys/statvfs.h>
 #include <sys/stropts.h>
 #include <sys/syscall.h>
 #include <sys/sysinfo.h>

--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -181,6 +181,7 @@
 #define DT_FIFO __WASI_FILETYPE_SOCKET_STREAM
 #define DT_LNK __WASI_FILETYPE_SYMBOLIC_LINK
 #define DT_REG __WASI_FILETYPE_REGULAR_FILE
+#define DT_SOCK 20
 #define DT_UNKNOWN __WASI_FILETYPE_UNKNOWN
 #define D_FMT 0x20029
 #define D_T_FMT 0x20028
@@ -1637,6 +1638,18 @@
 #define STRU_F 1
 #define STRU_P 3
 #define STRU_R 2
+#define ST_APPEND 256
+#define ST_IMMUTABLE 512
+#define ST_MANDLOCK 64
+#define ST_NOATIME 1024
+#define ST_NODEV 4
+#define ST_NODIRATIME 2048
+#define ST_NOEXEC 8
+#define ST_NOSUID 2
+#define ST_RDONLY 1
+#define ST_RELATIME 4096
+#define ST_SYNCHRONOUS 16
+#define ST_WRITE 128
 #define SUN_LEN(s) (2+strlen((s)->sun_path))
 #define SUSP 237
 #define SYMLOOP_MAX 40
@@ -1651,7 +1664,7 @@
 #define S_IFBLK (0x6000)
 #define S_IFCHR (0x2000)
 #define S_IFDIR (0x4000)
-#define S_IFIFO (0xc000)
+#define S_IFIFO (0x1000)
 #define S_IFLNK (0xa000)
 #define S_IFMT (S_IFBLK | S_IFCHR | S_IFDIR | S_IFIFO | S_IFLNK | S_IFREG | S_IFSOCK)
 #define S_IFREG (0x8000)
@@ -2018,7 +2031,7 @@
 #define _Complex_I (0.0f+1.0fi)
 #define _DIRENT_H 
 #define _DIRENT_HAVE_D_TYPE 
-#define _DLFCN_H
+#define _DLFCN_H 
 #define _ENDIAN_H 
 #define _ERRNO_H 
 #define _ERR_H 
@@ -2323,6 +2336,7 @@
 #define _SYS_REG_H 
 #define _SYS_SELECT_H 
 #define _SYS_SOCKET_H 
+#define _SYS_STATVFS_H 
 #define _SYS_STAT_H 
 #define _SYS_SYSCALL_H 
 #define _SYS_SYSINFO_H 
@@ -3146,6 +3160,7 @@
 #define fsfilcnt64_t fsfilcnt_t
 #define fstat64 fstat
 #define fstatat64 fstatat
+#define fstatvfs64 fstatvfs
 #define ftello64 ftello
 #define ftruncate64 ftruncate
 #define getdents64 getdents
@@ -3329,6 +3344,7 @@
 #define st_mtime st_mtim.tv_sec
 #define stat64 stat
 #define static_assert _Static_assert
+#define statvfs64 statvfs
 #define stderr (stderr)
 #define stdin (stdin)
 #define stdout (stdout)

--- a/libc-bottom-half/headers/public/__header_dirent.h
+++ b/libc-bottom-half/headers/public/__header_dirent.h
@@ -11,6 +11,13 @@
 #define DT_REG __WASI_FILETYPE_REGULAR_FILE
 #define DT_UNKNOWN __WASI_FILETYPE_UNKNOWN
 
+// DT_SOCK is not supported in WASI Preview 1 (but will be in Preview 2).  We
+// define it regardless so that libc++'s `<filesystem>` implementation builds.
+// The exact value is mostly arbitrary, but chosen so it doesn't conflict with
+// any of the existing `__WASI_FILETYPE_*` flags.  We do not expect any new
+// flags to be added to WASI Preview 1, so that should be sufficient.
+#define DT_SOCK 20
+
 #define IFTODT(x) (__wasilibc_iftodt(x))
 #define DTTOIF(x) (__wasilibc_dttoif(x))
 

--- a/libc-bottom-half/headers/public/__mode_t.h
+++ b/libc-bottom-half/headers/public/__mode_t.h
@@ -9,7 +9,7 @@
 #define S_IFLNK (0xa000)
 #define S_IFREG (0x8000)
 #define S_IFSOCK (0xc000)
-#define S_IFIFO (0xc000)
+#define S_IFIFO (0x1000)
 
 #define S_ISBLK(m) (((m)&S_IFMT) == S_IFBLK)
 #define S_ISCHR(m) (((m)&S_IFMT) == S_IFCHR)

--- a/libc-bottom-half/sources/posix.c
+++ b/libc-bottom-half/sources/posix.c
@@ -6,6 +6,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <sys/stat.h>
+#include <sys/statvfs.h>
 #include <unistd.h>
 #include <utime.h>
 #include <wasi/libc.h>
@@ -307,6 +308,46 @@ int rename(const char *old, const char *new) {
 
     // We couldn't find a preopen for it; fail as if we can't find the path.
     errno = ENOENT;
+    return -1;
+}
+
+int chmod(const char *path, mode_t mode) {
+    // TODO: We plan to support this eventually in WASI, but not yet.
+    // Meanwhile, we provide a stub so that libc++'s `<filesystem>`
+    // implementation will build unmodified.
+    errno = ENOSYS;
+    return -1;
+}
+
+int fchmod(int fd, mode_t mode) {
+    // TODO: We plan to support this eventually in WASI, but not yet.
+    // Meanwhile, we provide a stub so that libc++'s `<filesystem>`
+    // implementation will build unmodified.
+    errno = ENOSYS;
+    return -1;
+}
+
+int fchmodat(int fd, const char *path, mode_t mode, int flag) {
+    // TODO: We plan to support this eventually in WASI, but not yet.
+    // Meanwhile, we provide a stub so that libc++'s `<filesystem>`
+    // implementation will build unmodified.
+    errno = ENOSYS;
+    return -1;
+}
+
+int statvfs(const char *__restrict path, struct statvfs *__restrict buf) {
+    // TODO: We plan to support this eventually in WASI, but not yet.
+    // Meanwhile, we provide a stub so that libc++'s `<filesystem>`
+    // implementation will build unmodified.
+    errno = ENOSYS;
+    return -1;
+}
+
+int fstatvfs(int fd, struct statvfs *buf) {
+    // TODO: We plan to support this eventually in WASI, but not yet.
+    // Meanwhile, we provide a stub so that libc++'s `<filesystem>`
+    // implementation will build unmodified.
+    errno = ENOSYS;
     return -1;
 }
 

--- a/libc-top-half/musl/include/stdlib.h
+++ b/libc-top-half/musl/include/stdlib.h
@@ -128,9 +128,7 @@ int rand_r (unsigned *);
 
 #if defined(_XOPEN_SOURCE) || defined(_GNU_SOURCE) \
  || defined(_BSD_SOURCE)
-#ifdef __wasilibc_unmodified_upstream /* WASI has no absolute paths */
 char *realpath (const char *__restrict, char *__restrict);
-#endif
 long int random (void);
 void srandom (unsigned int);
 char *initstate (unsigned int, char *, size_t);

--- a/libc-top-half/musl/include/sys/stat.h
+++ b/libc-top-half/musl/include/sys/stat.h
@@ -78,11 +78,9 @@ int stat(const char *__restrict, struct stat *__restrict);
 int fstat(int, struct stat *);
 int lstat(const char *__restrict, struct stat *__restrict);
 int fstatat(int, const char *__restrict, struct stat *__restrict, int);
-#ifdef __wasilibc_unmodified_upstream /* WASI has no chmod */
 int chmod(const char *, mode_t);
 int fchmod(int, mode_t);
 int fchmodat(int, const char *, mode_t, int);
-#endif
 #ifdef __wasilibc_unmodified_upstream /* WASI has no umask */
 mode_t umask(mode_t);
 #endif


### PR DESCRIPTION
Per https://github.com/WebAssembly/wasi-sdk/issues/373, LLVM's libc++ no longer allows us to enable `<fstream>` and `<filesystem>` separately -- it's both or neither.  Consequently, we either need to patch libc++ to not use `statvfs`, `chmod`, etc. or add stub functions for those features to `wasi-libc`.  Since we're planning to eventually support those features with WASI Preview 2 and beyond, it makes sense to do the latter.

Note that since libc++ uses `DT_SOCK`, I've added a definition for it -- even though WASI Preview 1 does not define it.  No Preview 1 file will ever have that type, so code that handles that type will never be reached, but defining it allows us to avoid WASI-specific patches to libc++.

Related to `DT_SOCK`, I had to change the `S_IFIFO` value so it does not conflict with `S_IFSOCK`, thereby avoiding ambiguity in `__wasilibc_iftodt`.