### PR TITLE
Experimental setjmp/longjmp support

### DIFF
--- a/expected/wasm32-wasi-preview2/include-all.c
+++ b/expected/wasm32-wasi-preview2/include-all.c
@@ -117,6 +117,7 @@
 #include <sched.h>
 #include <search.h>
 #include <semaphore.h>
+#include <setjmp.h>
 #include <stdalign.h>
 #include <stdbool.h>
 #include <stdc-predef.h>

--- a/expected/wasm32-wasi-preview2/predefined-macros.txt
+++ b/expected/wasm32-wasi-preview2/predefined-macros.txt
@@ -2412,6 +2412,7 @@
 #define _SC_XOPEN_XPG4 100
 #define _SEARCH_H 
 #define _SEMAPHORE_H 
+#define _SETJMP_H
 #define _SIZE_T 
 #define _STDALIGN_H 
 #define _STDBOOL_H 

--- a/expected/wasm32-wasi-threads/include-all.c
+++ b/expected/wasm32-wasi-threads/include-all.c
@@ -118,6 +118,7 @@
 #include <sched.h>
 #include <search.h>
 #include <semaphore.h>
+#include <setjmp.h>
 #include <stdalign.h>
 #include <stdbool.h>
 #include <stdc-predef.h>

--- a/expected/wasm32-wasi-threads/predefined-macros.txt
+++ b/expected/wasm32-wasi-threads/predefined-macros.txt
@@ -2352,6 +2352,7 @@
 #define _SC_XOPEN_XPG4 100
 #define _SEARCH_H 
 #define _SEMAPHORE_H 
+#define _SETJMP_H
 #define _SIZE_T 
 #define _STDALIGN_H 
 #define _STDBOOL_H 

--- a/expected/wasm32-wasi/include-all.c
+++ b/expected/wasm32-wasi/include-all.c
@@ -117,6 +117,7 @@
 #include <sched.h>
 #include <search.h>
 #include <semaphore.h>
+#include <setjmp.h>
 #include <stdalign.h>
 #include <stdbool.h>
 #include <stdc-predef.h>

--- a/expected/wasm32-wasi/predefined-macros.txt
+++ b/expected/wasm32-wasi/predefined-macros.txt
@@ -2315,6 +2315,7 @@
 #define _SC_XOPEN_XPG4 100
 #define _SEARCH_H 
 #define _SEMAPHORE_H 
+#define _SETJMP_H
 #define _SIZE_T 
 #define _STDALIGN_H 
 #define _STDBOOL_H 

--- a/libc-top-half/musl/arch/wasm32/bits/setjmp.h
+++ b/libc-top-half/musl/arch/wasm32/bits/setjmp.h
@@ -1,0 +1,2 @@
+/* note: right now, only the first word is actually used */
+typedef unsigned long __jmp_buf[8];

--- a/libc-top-half/musl/include/setjmp.h
+++ b/libc-top-half/musl/include/setjmp.h
@@ -7,7 +7,8 @@ extern "C" {
 
 #include <features.h>
 
-#ifdef __wasilibc_unmodified_upstream /* WASI has no setjmp */
+/* WASI has no setjmp */
+#if defined(__wasilibc_unmodified_upstream) || defined(__wasm_exception_handling__)
 #include <bits/setjmp.h>
 
 typedef struct __jmp_buf_tag {

--- a/libc-top-half/musl/src/setjmp/wasm32/rt.c
+++ b/libc-top-half/musl/src/setjmp/wasm32/rt.c
@@ -1,0 +1,90 @@
+/*
+ * https://github.com/llvm/llvm-project/blob/main/llvm/lib/Target/WebAssembly/WebAssemblyLowerEmscriptenEHSjLj.cpp
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+
+struct entry {
+        uint32_t id;
+        uint32_t label;
+};
+
+static _Thread_local struct state {
+        uint32_t id;
+        uint32_t size;
+        struct arg {
+                void *env;
+                int val;
+        } arg;
+} g_state;
+
+/*
+ * table is allocated at the entry of functions which call setjmp.
+ *
+ *   table = malloc(40);
+ *   size = 4;
+ *   *(int *)table = 0;
+ */
+_Static_assert(sizeof(struct entry) * (4 + 1) <= 40, "entry size");
+
+void *
+saveSetjmp(void *env, uint32_t label, void *table, uint32_t size)
+{
+        struct state *state = &g_state;
+        struct entry *e = table;
+        uint32_t i;
+        for (i = 0; i < size; i++) {
+                if (e[i].id == 0) {
+                        uint32_t id = ++state->id;
+                        *(uint32_t *)env = id;
+                        e[i].id = id;
+                        e[i].label = label;
+                        /*
+                         * note: only the first word is zero-initialized
+                         * by the caller.
+                         */
+                        e[i + 1].id = 0;
+                        goto done;
+                }
+        }
+        size *= 2;
+        void *p = realloc(table, sizeof(*e) * (size + 1));
+        if (p == NULL) {
+                __builtin_trap();
+        }
+        table = p;
+done:
+        state->size = size;
+        return table;
+}
+
+uint32_t
+testSetjmp(unsigned int id, void *table, uint32_t size)
+{
+        struct entry *e = table;
+        uint32_t i;
+        for (i = 0; i < size; i++) {
+                if (e[i].id == id) {
+                        return e[i].label;
+                }
+        }
+        return 0;
+}
+
+uint32_t
+getTempRet0()
+{
+        struct state *state = &g_state;
+        return state->size;
+}
+
+void
+__wasm_longjmp(void *env, int val)
+{
+        struct state *state = &g_state;
+        struct arg *arg = &state->arg;
+        arg->env = env;
+        arg->val = val;
+        __builtin_wasm_throw(1, arg);
+}


### PR DESCRIPTION
Basically copy-and-paste from:
https://github.com/yamt/garbage/tree/master/wasm/longjmp

While it seems working well, it's disabled by default because:

* It might be controversial if it's a good idea to use this emscripten API for WASI as well.

* LLVM produces bytecode for an old version of the EH proposal.

* The EH proposal is not widely implemeted in runtimes yet. Maybe it isn't a problem for libc.a. But for libc.so, it would be a disaster for runtimes w/o EH.

Tested with `binaryen --translate-eh-old-to-new` and toywasm:

* build wasi-libc with BUILD_SJLJ=yes
* build your app with "-mllvm -wasm-enable-sjlj"
* apply "wasm-opt --translate-eh-old-to-new"
* run with "toywasm --wasi"

Besides that, for libc.so, your embedder needs to provide "env:__c_longjmp".