### PR TITLE
add preview2_component_type.o to libc.a and libc.so

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -383,6 +383,9 @@ DLMALLOC_OBJS = $(call objs,$(DLMALLOC_SOURCES))
 EMMALLOC_OBJS = $(call objs,$(EMMALLOC_SOURCES))
 LIBC_BOTTOM_HALF_ALL_OBJS = $(call objs,$(LIBC_BOTTOM_HALF_ALL_SOURCES))
 LIBC_TOP_HALF_ALL_OBJS = $(call asmobjs,$(call objs,$(LIBC_TOP_HALF_ALL_SOURCES)))
+ifeq ($(WASI_SNAPSHOT), preview2)
+LIBC_OBJS += $(OBJDIR)/preview2_component_type.o
+endif
 ifeq ($(MALLOC_IMPL),dlmalloc)
 LIBC_OBJS += $(DLMALLOC_OBJS)
 else ifeq ($(MALLOC_IMPL),emmalloc)
@@ -603,6 +606,10 @@ $(LIBWASI_EMULATED_SIGNAL_MUSL_OBJS) $(LIBWASI_EMULATED_SIGNAL_MUSL_SO_OBJS): CF
 $(OBJDIR)/%.long-double.pic.o: %.c include_dirs
 	@mkdir -p "$(@D)"
 	$(CC) $(CFLAGS) -MD -MP -o $@ -c $<
+
+$(OBJDIR)/preview2_component_type.pic.o $(OBJDIR)/preview2_component_type.o: $(LIBC_BOTTOM_HALF_SOURCES)/preview2_component_type.o
+	@mkdir -p "$(@D)"
+	cp $< $@
 
 $(OBJDIR)/%.pic.o: %.c include_dirs
 	@mkdir -p "$(@D)"

--- a/expected/wasm32-wasi-preview2/defined-symbols.txt
+++ b/expected/wasm32-wasi-preview2/defined-symbols.txt
@@ -19,6 +19,7 @@ __c_locale
 __clock
 __clock_gettime
 __clock_nanosleep
+__component_type_object_force_link_preview2
 __component_type_object_force_link_preview2_public_use_in_this_compilation_unit
 __cos
 __cosdf

--- a/expected/wasm32-wasi-preview2/undefined-symbols.txt
+++ b/expected/wasm32-wasi-preview2/undefined-symbols.txt
@@ -1,5 +1,4 @@
 __addtf3
-__component_type_object_force_link_preview2
 __divtf3
 __eqtf2
 __extenddftf2


### PR DESCRIPTION
This file adds a custom section to each core module linked with wasi-libc.  That custom section contains component type information needed by e.g. `wasm-tools component new` to generate a component from the module.  It will be required once we start using any part of WASI 0.2.0 directly (vs. via a Preview 1 adapter).  In addition, it allows developers to `#include <wasi/preview2.h>` in their code and make use of those APIs directly even if wasi-libc is not using them yet.