### PR TITLE
add realpath.c to `LIBC_TOP_HALF_MUSL_SOURCES`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -127,6 +127,7 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
         misc/getopt.c \
         misc/getopt_long.c \
         misc/getsubopt.c \
+        misc/realpath.c \
         misc/uname.c \
         misc/nftw.c \
         errno/strerror.c \

--- a/expected/wasm32-wasi-preview2/defined-symbols.txt
+++ b/expected/wasm32-wasi-preview2/defined-symbols.txt
@@ -1050,6 +1050,7 @@ readlinkat
 readv
 realloc
 reallocarray
+realpath
 recv
 regcomp
 regerror

--- a/expected/wasm32-wasi-threads/defined-symbols.txt
+++ b/expected/wasm32-wasi-threads/defined-symbols.txt
@@ -1084,6 +1084,7 @@ readlinkat
 readv
 realloc
 reallocarray
+realpath
 recv
 regcomp
 regerror

--- a/expected/wasm32-wasi/defined-symbols.txt
+++ b/expected/wasm32-wasi/defined-symbols.txt
@@ -941,6 +941,7 @@ readlinkat
 readv
 realloc
 reallocarray
+realpath
 recv
 regcomp
 regerror

--- a/libc-bottom-half/sources/posix.c
+++ b/libc-bottom-half/sources/posix.c
@@ -351,6 +351,13 @@ int fstatvfs(int fd, struct statvfs *buf) {
     return -1;
 }
 
+char *realpath (const char *__restrict file_name, char *__restrict resolved_name) {
+    // TODO: We plan to support this eventually in WASI, but not yet.
+    // Meanwhile, we provide a stub so that libc++'s `<filesystem>`
+    // implementation will build unmodified.
+    return NULL;
+}
+
 // Like `access`, but with `faccessat`'s flags argument.
 int
 __wasilibc_access(const char *path, int mode, int flags)

--- a/libc-bottom-half/sources/posix.c
+++ b/libc-bottom-half/sources/posix.c
@@ -351,13 +351,6 @@ int fstatvfs(int fd, struct statvfs *buf) {
     return -1;
 }
 
-char *realpath (const char *__restrict file_name, char *__restrict resolved_name) {
-    // TODO: We plan to support this eventually in WASI, but not yet.
-    // Meanwhile, we provide a stub so that libc++'s `<filesystem>`
-    // implementation will build unmodified.
-    return NULL;
-}
-
 // Like `access`, but with `faccessat`'s flags argument.
 int
 __wasilibc_access(const char *path, int mode, int flags)


### PR DESCRIPTION
In https://github.com/WebAssembly/wasi-libc/pull/463, I added stubs for `statvfs`, `chmod`, etc. and removed the `ifdef` around the `realpath` declaration, but neglected to add a `realpath` implementation.  Now we use musl's implementation.