### PR TITLE
add `__wasilibc_reset_preopens`

### DIFF
--- a/expected/wasm32-wasip1-threads/defined-symbols.txt
+++ b/expected/wasm32-wasip1-threads/defined-symbols.txt
@@ -395,6 +395,7 @@ __wasilibc_pthread_self
 __wasilibc_register_preopened_fd
 __wasilibc_rename_newat
 __wasilibc_rename_oldat
+__wasilibc_reset_preopens
 __wasilibc_rmdirat
 __wasilibc_stat
 __wasilibc_tell

--- a/expected/wasm32-wasip1/defined-symbols.txt
+++ b/expected/wasm32-wasip1/defined-symbols.txt
@@ -333,6 +333,7 @@ __wasilibc_populate_preopens
 __wasilibc_register_preopened_fd
 __wasilibc_rename_newat
 __wasilibc_rename_oldat
+__wasilibc_reset_preopens
 __wasilibc_rmdirat
 __wasilibc_stat
 __wasilibc_tell

--- a/expected/wasm32-wasip2/defined-symbols.txt
+++ b/expected/wasm32-wasip2/defined-symbols.txt
@@ -348,6 +348,7 @@ __wasilibc_populate_preopens
 __wasilibc_register_preopened_fd
 __wasilibc_rename_newat
 __wasilibc_rename_oldat
+__wasilibc_reset_preopens
 __wasilibc_rmdirat
 __wasilibc_stat
 __wasilibc_tell

--- a/libc-bottom-half/sources/preopens.c
+++ b/libc-bottom-half/sources/preopens.c
@@ -260,7 +260,7 @@ void __wasilibc_populate_preopens(void) {
             if (prefix == NULL)
                 goto software;
 
-            // TODO: Remove the cast on `path` once the witx is updated with
+            // TODO: Remove the cast on `prefix` once the witx is updated with
             // char8 support.
             ret = __wasi_fd_prestat_dir_name(fd, (uint8_t *)prefix,
                                              prestat.u.dir.pr_name_len);
@@ -289,4 +289,24 @@ oserr:
     _Exit(EX_OSERR);
 software:
     _Exit(EX_SOFTWARE);
+}
+
+void __wasilibc_reset_preopens(void) {
+    LOCK(lock);
+
+    if (num_preopens) {
+        for (int i = 0; i < num_preopens; ++i) {
+            free((void*) preopens[i].prefix);
+        }
+        free(preopens);
+    }
+    
+    preopens_populated = false;
+    preopens = NULL;
+    num_preopens = 0;
+    preopen_capacity = 0;
+    
+    assert_invariants();
+    
+    UNLOCK(lock);
 }


### PR DESCRIPTION
This resets the preopens table to an uninitialized state, forcing it to be reinitialized next time it is needed.  This is useful when pre-initializing using e.g. `wizer` or `component-init`.  Such tools are capable of taking a snapshot of a running application which may later be resumed on an unrelated runtime (which may have its own, unrelated preopens).