### PR TITLE
dlmalloc: account the footprint of the initial heap

### DIFF
--- a/dlmalloc/src/malloc.c
+++ b/dlmalloc/src/malloc.c
@@ -5250,6 +5250,8 @@ static void try_init_allocator(void) {
   gm->least_addr = base;
   gm->seg.base = base;
   gm->seg.size = initial_heap_size;
+  gm->footprint = initial_heap_size;
+  gm->max_footprint = initial_heap_size;
   gm->magic = mparams.magic;
   gm->release_checks = MAX_RELEASE_CHECK_RATE;
   init_bins(gm);


### PR DESCRIPTION
While malloc_stats and friends are disabled and unused for wasi-libc, it's neater to be consistent.

Background: My colleagues for some reasons enabled malloc_stats and asked me why it reports negative values.

Note: Depending __heap_base, init_top() adjusts the address for alignment. I think the amount of this adjustment is reported as "used" by malloc_stats. I don't bother to "fix" it.