### PR TITLE
Ignore the `__tls_base` undefined symbol

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -836,7 +836,7 @@ check-symbols: startup_files libc
 	for undef_sym in $$("$(NM)" --undefined-only "$(SYSROOT_LIB)"/libc.a "$(SYSROOT_LIB)"/libc-*.a "$(SYSROOT_LIB)"/*.o \
 	    |grep ' U ' |sed 's/.* U //' |LC_ALL=C sort |uniq); do \
 	    grep -q '\<'$$undef_sym'\>' "$(DEFINED_SYMBOLS)" || echo $$undef_sym; \
-	done | grep -E -v "^__mul|__memory_base|__indirect_function_table" > "$(UNDEFINED_SYMBOLS)"
+	done | grep -E -v "^__mul|__memory_base|__indirect_function_table|__tls_base" > "$(UNDEFINED_SYMBOLS)"
 	grep '^_*imported_wasi_' "$(UNDEFINED_SYMBOLS)" \
 	    > "$(SYSROOT_LIB)/libc.imports"
 

--- a/expected/wasm32-wasip1-threads/undefined-symbols.txt
+++ b/expected/wasm32-wasip1-threads/undefined-symbols.txt
@@ -66,7 +66,6 @@ __netf2
 __stack_pointer
 __subtf3
 __tls_align
-__tls_base
 __tls_size
 __trunctfdf2
 __trunctfsf2


### PR DESCRIPTION
Currently if `-g` is specified with build flags then wasi-libc fails to build. I'm not certain why it shows up in object files, but it appears to be a spurious error so this commit adds it to the list of variables to ignore.