### PR TITLE
include pthread.h for all targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -539,11 +539,6 @@ ifeq ($(WASI_SNAPSHOT), p1)
 MUSL_OMIT_HEADERS += "netdb.h"
 endif
 
-ifeq ($(THREAD_MODEL), single)
-# Remove headers not supported in single-threaded mode.
-MUSL_OMIT_HEADERS += "pthread.h"
-endif
-
 default: finish
 
 LIBC_SO_OBJS = $(patsubst %.o,%.pic.o,$(filter-out $(MUSL_PRINTSCAN_OBJS),$(LIBC_OBJS)))

--- a/expected/wasm32-wasip1/include-all.c
+++ b/expected/wasm32-wasip1/include-all.c
@@ -114,6 +114,7 @@
 #include <netpacket/packet.h>
 #include <nl_types.h>
 #include <poll.h>
+#include <pthread.h>
 #include <regex.h>
 #include <sched.h>
 #include <search.h>

--- a/expected/wasm32-wasip1/predefined-macros.txt
+++ b/expected/wasm32-wasip1/predefined-macros.txt
@@ -1419,6 +1419,35 @@
 #define PRIxLEAST8 __UINT_LEAST8_FMTx__
 #define PRIxMAX __UINTMAX_FMTx__
 #define PRIxPTR __UINTPTR_FMTx__
+#define PTHREAD_BARRIER_SERIAL_THREAD (-1)
+#define PTHREAD_CANCELED ((void *)-1)
+#define PTHREAD_CANCEL_ASYNCHRONOUS 1
+#define PTHREAD_CANCEL_DEFERRED 0
+#define PTHREAD_CANCEL_DISABLE 1
+#define PTHREAD_CANCEL_ENABLE 0
+#define PTHREAD_CANCEL_MASKED 2
+#define PTHREAD_COND_INITIALIZER {{{0}}}
+#define PTHREAD_CREATE_DETACHED 1
+#define PTHREAD_CREATE_JOINABLE 0
+#define PTHREAD_EXPLICIT_SCHED 1
+#define PTHREAD_INHERIT_SCHED 0
+#define PTHREAD_MUTEX_DEFAULT 0
+#define PTHREAD_MUTEX_ERRORCHECK 2
+#define PTHREAD_MUTEX_INITIALIZER {{{0}}}
+#define PTHREAD_MUTEX_NORMAL 0
+#define PTHREAD_MUTEX_RECURSIVE 1
+#define PTHREAD_MUTEX_ROBUST 1
+#define PTHREAD_MUTEX_STALLED 0
+#define PTHREAD_NULL ((pthread_t)0)
+#define PTHREAD_ONCE_INIT 0
+#define PTHREAD_PRIO_INHERIT 1
+#define PTHREAD_PRIO_NONE 0
+#define PTHREAD_PRIO_PROTECT 2
+#define PTHREAD_PROCESS_PRIVATE 0
+#define PTHREAD_PROCESS_SHARED 1
+#define PTHREAD_RWLOCK_INITIALIZER {{{0}}}
+#define PTHREAD_SCOPE_PROCESS 1
+#define PTHREAD_SCOPE_SYSTEM 0
 #define PTRBITS (sizeof(char *) * 8)
 #define PTRDIFF_MAX INT32_MAX
 #define PTRDIFF_MIN INT32_MIN
@@ -2163,6 +2192,7 @@
 #define _POSIX_V7_ILP32_OFFBIG (1)
 #define _POSIX_VDISABLE 0
 #define _POSIX_VERSION 200809L
+#define _PTHREAD_H 
 #define _PTRDIFF_T 
 #define _REGEX_H 
 #define _SCHED_H 
@@ -3006,7 +3036,7 @@
 #define __tg_real_remquo(x,y,z) (__RETCAST_2(x, y)( __FLT(x) && __FLT(y) ? remquof(x, y, z) : __LDBL((x)+(y)) ? remquol(x, y, z) : remquo(x, y, z) ))
 #define __tm_gmtoff tm_gmtoff
 #define __tm_zone tm_zone
-#define __va_copy(d,s) __builtin_va_copy(d,s)
+#define __va_copy(d,s) __builtin_va_copy(d, s)
 #define __wasi__ 1
 #define __wasi_api_h 
 #define __wasi_libc_environ_h 
@@ -3312,6 +3342,9 @@
 #define powerof2(n) !(((n)-1) & (n))
 #define pread64 pread
 #define preadv64 preadv
+#define pthread_cleanup_pop(r) _pthread_cleanup_pop(&__cb, (r)); } while(0)
+#define pthread_cleanup_push(f,x) do { struct __ptcb __cb; _pthread_cleanup_push(&__cb, f, x);
+#define pthread_equal(x,y) ((x)==(y))
 #define pwrite64 pwrite
 #define pwritev64 pwritev
 #define readdir64 readdir

--- a/expected/wasm32-wasip2/include-all.c
+++ b/expected/wasm32-wasip2/include-all.c
@@ -115,6 +115,7 @@
 #include <netpacket/packet.h>
 #include <nl_types.h>
 #include <poll.h>
+#include <pthread.h>
 #include <regex.h>
 #include <sched.h>
 #include <search.h>

--- a/expected/wasm32-wasip2/predefined-macros.txt
+++ b/expected/wasm32-wasip2/predefined-macros.txt
@@ -1550,6 +1550,35 @@
 #define PRIxLEAST8 __UINT_LEAST8_FMTx__
 #define PRIxMAX __UINTMAX_FMTx__
 #define PRIxPTR __UINTPTR_FMTx__
+#define PTHREAD_BARRIER_SERIAL_THREAD (-1)
+#define PTHREAD_CANCELED ((void *)-1)
+#define PTHREAD_CANCEL_ASYNCHRONOUS 1
+#define PTHREAD_CANCEL_DEFERRED 0
+#define PTHREAD_CANCEL_DISABLE 1
+#define PTHREAD_CANCEL_ENABLE 0
+#define PTHREAD_CANCEL_MASKED 2
+#define PTHREAD_COND_INITIALIZER {{{0}}}
+#define PTHREAD_CREATE_DETACHED 1
+#define PTHREAD_CREATE_JOINABLE 0
+#define PTHREAD_EXPLICIT_SCHED 1
+#define PTHREAD_INHERIT_SCHED 0
+#define PTHREAD_MUTEX_DEFAULT 0
+#define PTHREAD_MUTEX_ERRORCHECK 2
+#define PTHREAD_MUTEX_INITIALIZER {{{0}}}
+#define PTHREAD_MUTEX_NORMAL 0
+#define PTHREAD_MUTEX_RECURSIVE 1
+#define PTHREAD_MUTEX_ROBUST 1
+#define PTHREAD_MUTEX_STALLED 0
+#define PTHREAD_NULL ((pthread_t)0)
+#define PTHREAD_ONCE_INIT 0
+#define PTHREAD_PRIO_INHERIT 1
+#define PTHREAD_PRIO_NONE 0
+#define PTHREAD_PRIO_PROTECT 2
+#define PTHREAD_PROCESS_PRIVATE 0
+#define PTHREAD_PROCESS_SHARED 1
+#define PTHREAD_RWLOCK_INITIALIZER {{{0}}}
+#define PTHREAD_SCOPE_PROCESS 1
+#define PTHREAD_SCOPE_SYSTEM 0
 #define PTRBITS (sizeof(char *) * 8)
 #define PTRDIFF_MAX INT32_MAX
 #define PTRDIFF_MIN INT32_MIN
@@ -2314,6 +2343,7 @@
 #define _POSIX_V7_ILP32_OFFBIG (1)
 #define _POSIX_VDISABLE 0
 #define _POSIX_VERSION 200809L
+#define _PTHREAD_H 
 #define _PTRDIFF_T 
 #define _REGEX_H 
 #define _SCHED_H 
@@ -3467,6 +3497,9 @@
 #define powerof2(n) !(((n)-1) & (n))
 #define pread64 pread
 #define preadv64 preadv
+#define pthread_cleanup_pop(r) _pthread_cleanup_pop(&__cb, (r)); } while(0)
+#define pthread_cleanup_push(f,x) do { struct __ptcb __cb; _pthread_cleanup_push(&__cb, f, x);
+#define pthread_equal(x,y) ((x)==(y))
 #define pwrite64 pwrite
 #define pwritev64 pwritev
 #define readdir64 readdir


### PR DESCRIPTION
Per #501, this restores the pre-WASI-SDK-22 behavior of including a copy of pthread.h for all targets -- not just the `*-threads` targets. This helps minimize the number of preprocessor guards required to port existing POSIX software to WASI. It also make it easier for projects using WASI-SDK versions earlier than 22 to upgrade.

Note that this includes the pthread.h header, but no stub function definitions to link against. We should probably provide the latter as well, but I'll leave that for a separate PR.