### PR TITLE
0-initialize thread-specific data upon thread creation.

### DIFF
--- a/libc-top-half/musl/src/thread/pthread_create.c
+++ b/libc-top-half/musl/src/thread/pthread_create.c
@@ -458,6 +458,9 @@ int __pthread_create(pthread_t *restrict res, const pthread_attr_t *restrict att
 		if (!map) goto fail;
 #endif
 		tsd = map + size - __pthread_tsd_size;
+#ifndef __wasilibc_unmodified_upstream
+	        memset(tsd, 0, __pthread_tsd_size);
+#endif
 		if (!stack) {
 #ifdef __wasilibc_unmodified_upstream
 			stack = tsd - libc.tls_size;


### PR DESCRIPTION
If thread-specific data is not set to 0 upon thread creation, `__pthread_tsd_run_dtors` will end up running destructors passing uninitialized memory as memory addresses, which can lead to memory corruption.

This issue can be triggered when malloc() returns a memory address that was freed before, as in that case memory is not zeroed out.