### PR TITLE
`times` should always return 0 for `tms_cutime`

### DIFF
--- a/libc-bottom-half/clocks/times.c
+++ b/libc-bottom-half/clocks/times.c
@@ -17,7 +17,8 @@ clock_t times(struct tms *buffer) {
     __wasi_timestamp_t user = __clock();
     *buffer = (struct tms){
         .tms_utime = user,
-        .tms_cutime = user
+        // WASI doesn't provide a way to spawn a new process, so always 0.
+        .tms_cutime = 0
     };
 
     __wasi_timestamp_t realtime = 0;


### PR DESCRIPTION
`tms_cutime` is the sum of the user times of child processes *excluding the current process*. Since WASI doesn't provide a way to spawn a new process, this value should always be 0.

Interestingly PSPSDK had exactly the same issue and @fjtrujy found wasi-libc has the issue too 😅  https://github.com/pspdev/pspsdk/pull/193/files/eef342187319ead21cfe9a6598fd79a21188c1fa#diff-8318a7fe507925448c5a85d6bfdeb9f720a24b6d38d583eea8542758898cc4e7