### PR TITLE
Improve some pthreads stub functions, batch 1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -300,6 +300,7 @@ LIBC_TOP_HALF_MUSL_SOURCES += \
         thread/pthread_barrierattr_init.c \
         thread/pthread_barrierattr_setpshared.c \
         thread/pthread_cleanup_push.c \
+        thread/pthread_cancel.c \
         thread/pthread_cond_broadcast.c \
         thread/pthread_cond_destroy.c \
         thread/pthread_cond_init.c \
@@ -345,6 +346,7 @@ LIBC_TOP_HALF_MUSL_SOURCES += \
         thread/pthread_rwlockattr_init.c \
         thread/pthread_rwlockattr_setpshared.c \
         thread/pthread_setcancelstate.c \
+        thread/pthread_setcanceltype.c \
         thread/pthread_setspecific.c \
         thread/pthread_self.c \
         thread/pthread_spin_destroy.c \

--- a/Makefile
+++ b/Makefile
@@ -292,6 +292,7 @@ LIBC_TOP_HALF_MUSL_SOURCES += \
         thread/pthread_attr_setguardsize.c \
         thread/pthread_attr_setstack.c \
         thread/pthread_attr_setstacksize.c \
+        thread/pthread_attr_setschedparam.c \
         thread/pthread_barrier_destroy.c \
         thread/pthread_barrier_init.c \
         thread/pthread_barrier_wait.c \

--- a/expected/wasm32-wasip1-threads/defined-symbols.txt
+++ b/expected/wasm32-wasip1-threads/defined-symbols.txt
@@ -1009,6 +1009,7 @@ pthread_cond_signal
 pthread_cond_timedwait
 pthread_cond_wait
 pthread_condattr_destroy
+pthread_condattr_getclock
 pthread_condattr_getpshared
 pthread_condattr_init
 pthread_condattr_setclock

--- a/expected/wasm32-wasip1-threads/defined-symbols.txt
+++ b/expected/wasm32-wasip1-threads/defined-symbols.txt
@@ -1002,6 +1002,7 @@ pthread_barrierattr_destroy
 pthread_barrierattr_getpshared
 pthread_barrierattr_init
 pthread_barrierattr_setpshared
+pthread_cancel
 pthread_cond_broadcast
 pthread_cond_destroy
 pthread_cond_init
@@ -1056,6 +1057,7 @@ pthread_rwlockattr_init
 pthread_rwlockattr_setpshared
 pthread_self
 pthread_setcancelstate
+pthread_setcanceltype
 pthread_setspecific
 pthread_spin_destroy
 pthread_spin_init

--- a/expected/wasm32-wasip1-threads/defined-symbols.txt
+++ b/expected/wasm32-wasip1-threads/defined-symbols.txt
@@ -986,13 +986,14 @@ psignal
 pthread_attr_destroy
 pthread_attr_getdetachstate
 pthread_attr_getguardsize
-pthread_attr_getinheritsched
+pthread_attr_getschedparam
 pthread_attr_getscope
 pthread_attr_getstack
 pthread_attr_getstacksize
 pthread_attr_init
 pthread_attr_setdetachstate
 pthread_attr_setguardsize
+pthread_attr_setschedparam
 pthread_attr_setstack
 pthread_attr_setstacksize
 pthread_barrier_destroy

--- a/expected/wasm32-wasip1-threads/defined-symbols.txt
+++ b/expected/wasm32-wasip1-threads/defined-symbols.txt
@@ -987,7 +987,6 @@ pthread_attr_destroy
 pthread_attr_getdetachstate
 pthread_attr_getguardsize
 pthread_attr_getschedparam
-pthread_attr_getscope
 pthread_attr_getstack
 pthread_attr_getstacksize
 pthread_attr_init

--- a/libc-top-half/musl/include/sched.h
+++ b/libc-top-half/musl/include/sched.h
@@ -16,7 +16,6 @@ extern "C" {
 
 #include <bits/alltypes.h>
 
-#ifdef __wasilibc_unmodified_upstream /* WASI has no CPU scheduling support. */
 struct sched_param {
 	int sched_priority;
 	int __reserved1;
@@ -31,6 +30,7 @@ struct sched_param {
 	int __reserved3;
 };
 
+#ifdef __wasilibc_unmodified_upstream /* WASI has no CPU scheduling support. */
 int    sched_get_priority_max(int);
 int    sched_get_priority_min(int);
 int    sched_getparam(pid_t, struct sched_param *);

--- a/libc-top-half/musl/src/thread/pthread_attr_get.c
+++ b/libc-top-half/musl/src/thread/pthread_attr_get.c
@@ -11,13 +11,13 @@ int pthread_attr_getguardsize(const pthread_attr_t *restrict a, size_t *restrict
 	return 0;
 }
 
+#ifdef __wasilibc_unmodified_upstream /* WASI has no CPU scheduling support. */
 int pthread_attr_getinheritsched(const pthread_attr_t *restrict a, int *restrict inherit)
 {
 	*inherit = a->_a_sched;
 	return 0;
 }
 
-#ifdef __wasilibc_unmodified_upstream /* WASI has no CPU scheduling support. */
 int pthread_attr_getschedparam(const pthread_attr_t *restrict a, struct sched_param *restrict param)
 {
 	param->sched_priority = a->_a_prio;
@@ -27,6 +27,12 @@ int pthread_attr_getschedparam(const pthread_attr_t *restrict a, struct sched_pa
 int pthread_attr_getschedpolicy(const pthread_attr_t *restrict a, int *restrict policy)
 {
 	*policy = a->_a_policy;
+	return 0;
+}
+#else
+int pthread_attr_getschedparam(const pthread_attr_t *restrict a, struct sched_param *restrict param)
+{
+	param->sched_priority = 0;
 	return 0;
 }
 #endif

--- a/libc-top-half/musl/src/thread/pthread_attr_get.c
+++ b/libc-top-half/musl/src/thread/pthread_attr_get.c
@@ -29,6 +29,12 @@ int pthread_attr_getschedpolicy(const pthread_attr_t *restrict a, int *restrict 
 	*policy = a->_a_policy;
 	return 0;
 }
+
+int pthread_attr_getscope(const pthread_attr_t *restrict a, int *restrict scope)
+{
+	*scope = PTHREAD_SCOPE_SYSTEM;
+	return 0;
+}
 #else
 int pthread_attr_getschedparam(const pthread_attr_t *restrict a, struct sched_param *restrict param)
 {
@@ -36,12 +42,6 @@ int pthread_attr_getschedparam(const pthread_attr_t *restrict a, struct sched_pa
 	return 0;
 }
 #endif
-
-int pthread_attr_getscope(const pthread_attr_t *restrict a, int *restrict scope)
-{
-	*scope = PTHREAD_SCOPE_SYSTEM;
-	return 0;
-}
 
 int pthread_attr_getstack(const pthread_attr_t *restrict a, void **restrict addr, size_t *restrict size)
 {

--- a/libc-top-half/musl/src/thread/pthread_attr_get.c
+++ b/libc-top-half/musl/src/thread/pthread_attr_get.c
@@ -1,5 +1,9 @@
 #include "pthread_impl.h"
 
+#ifndef __wasilibc_unmodified_upstream
+#include <common/clock.h>
+#endif
+
 int pthread_attr_getdetachstate(const pthread_attr_t *a, int *state)
 {
 	*state = a->_a_detach;
@@ -68,6 +72,15 @@ int pthread_barrierattr_getpshared(const pthread_barrierattr_t *restrict a, int 
 int pthread_condattr_getclock(const pthread_condattr_t *restrict a, clockid_t *restrict clk)
 {
 	*clk = a->__attr & 0x7fffffff;
+	return 0;
+}
+#else
+int pthread_condattr_getclock(const pthread_condattr_t *restrict a, clockid_t *restrict clk)
+{
+	if (a->__attr & 0x7fffffff == __WASI_CLOCKID_REALTIME)
+		*clk = CLOCK_REALTIME;
+	if (a->__attr & 0x7fffffff == __WASI_CLOCKID_MONOTONIC)
+		*clk = CLOCK_MONOTONIC;
 	return 0;
 }
 #endif

--- a/libc-top-half/musl/src/thread/pthread_attr_setschedparam.c
+++ b/libc-top-half/musl/src/thread/pthread_attr_setschedparam.c
@@ -2,6 +2,10 @@
 
 int pthread_attr_setschedparam(pthread_attr_t *restrict a, const struct sched_param *restrict param)
 {
+#ifdef __wasilibc_unmodified_upstream
 	a->_a_prio = param->sched_priority;
+#else
+	if (param->sched_priority != 0) return ENOTSUP;
+#endif
 	return 0;
 }

--- a/libc-top-half/musl/src/thread/pthread_cancel.c
+++ b/libc-top-half/musl/src/thread/pthread_cancel.c
@@ -3,6 +3,7 @@
 #include "pthread_impl.h"
 #include "syscall.h"
 
+#ifdef __wasilibc_unmodified_upstream
 hidden long __cancel(), __syscall_cp_asm(), __syscall_cp_c();
 
 long __cancel()
@@ -99,3 +100,9 @@ int pthread_cancel(pthread_t t)
 	}
 	return pthread_kill(t, SIGCANCEL);
 }
+#else
+int pthread_cancel(pthread_t t)
+{
+	return ENOTSUP;
+}
+#endif

--- a/libc-top-half/musl/src/thread/pthread_setcancelstate.c
+++ b/libc-top-half/musl/src/thread/pthread_setcancelstate.c
@@ -2,12 +2,10 @@
 
 int __pthread_setcancelstate(int new, int *old)
 {
-#if defined(__wasilibc_unmodified_upstream) || defined(_REENTRANT)
 	if (new > 2U) return EINVAL;
 	struct pthread *self = __pthread_self();
 	if (old) *old = self->canceldisable;
 	self->canceldisable = new;
-#endif
 	return 0;
 }
 


### PR DESCRIPTION
This is the next part of breaking up #518 into smaller PRs.

This is the rest of the commits which change the existing `THREAD_MODEL=posix` functionality. It:

* _removes_ some functions which are optional and which were already nonfunctional.
* (Continues to) establish a precedent of trying to remain as compatible with Open Group specifications as possible, even when there are major differences in WASI capabilities (i.e. thread cancellation)

Compared to the RFC PR, the `pthread_atfork` stub has been dropped as it is now officially obsolete as of the very recent Issue 8 of the specifications.