### PR TITLE
Exclude setjmp runtime from LTO

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -264,6 +264,7 @@ LIBC_TOP_HALF_MUSL_SOURCES = \
 LIBC_NONLTO_SOURCES = \
     $(addprefix $(LIBC_TOP_HALF_MUSL_SRC_DIR)/, \
         exit/atexit.c \
+        setjmp/wasm32/rt.c \
     )
 
 ifeq ($(WASI_SNAPSHOT), p2)


### PR DESCRIPTION
This fixes errors like:
```
wasm-ld: error: /Volumes/PortableSSD/git/wasi-sdk/build/install/bin/../share/wasi-sysroot/lib/wasm32-wasi/llvm-lto/19.1.0-wasi-sdk/libsetjmp.a(rt.o): attempt to add bitcode file after LTO (__wasm_longjmp)
```

Note: Any symbol that the compiler might generate at bitcode compile time either need to be unconditionally included at LTO time, or not built as LTO. This is because LTO object files cannot be added to the link after LTO time.
