### PR TITLE
Preserve timestamps for installed headers to improve incremental builds

### DIFF
--- a/libc-bottom-half/headers/public/__wasi_snapshot.h
+++ b/libc-bottom-half/headers/public/__wasi_snapshot.h
@@ -1,5 +1,0 @@
-/* This file is (practically) empty by default.  The Makefile will replace it
-   with a non-empty version that defines `__wasilibc_use_wasip2` if targeting
-   `wasm32-wasip2`.
- */
-


### PR DESCRIPTION
This change makes it so that the timestamps of installed header files are only updated when the contents of the header files change. This change is beneficial for incremental builds of projects depending on wasi-libc. For example, the Swift project builds wasi-libc as part of its build process, and this change reduces the number of build products in the Swift build that are unnecessarily rebuilt.

The following commands can be used to verify the changes:
```bash
make clean && make -j16 && (
  cd sysroot && find . -name "*.h" -type f -exec stat -c '%n %y' {} \;
) > sysroot.v1.timestamp && \
make -j16 && (
  cd sysroot && find . -name "*.h" -type f -exec stat -c '%n %y' {} \;
) > sysroot.v2.timestamp
diff sysroot.v1.timestamp sysroot.v2.timestamp
```
The diff should show no changes in timestamps.

Eventually, unnecessary copyings themselves should be skipped but it requires making the wasi-libc build system to support complete incremental build.