### PR TITLE
Add SO_BROADCAST and SO_LINGER to the list of defined constants

### DIFF
--- a/expected/wasm32-wasip2/predefined-macros.txt
+++ b/expected/wasm32-wasip2/predefined-macros.txt
@@ -1776,9 +1776,11 @@
 #define SOL_UDP 17
 #define SOMAXCONN 128
 #define SO_ACCEPTCONN 30
+#define SO_BROADCAST 6
 #define SO_DOMAIN 39
 #define SO_ERROR 4
 #define SO_KEEPALIVE 9
+#define SO_LINGER 13
 #define SO_PROTOCOL 38
 #define SO_RCVBUF 8
 #define SO_RCVTIMEO 66

--- a/libc-bottom-half/headers/public/__header_sys_socket.h
+++ b/libc-bottom-half/headers/public/__header_sys_socket.h
@@ -28,9 +28,11 @@
 
 #define SO_REUSEADDR 2
 #define SO_ERROR 4
+#define SO_BROADCAST 6
 #define SO_SNDBUF 7
 #define SO_RCVBUF 8
 #define SO_KEEPALIVE 9
+#define SO_LINGER 13
 #define SO_ACCEPTCONN 30
 #define SO_PROTOCOL 38
 #define SO_DOMAIN 39


### PR DESCRIPTION
Instead of just defining the constants which are needed by Rust's standard library, would it make sense to simply expose all `SO_` constants? And if so, would it be a good idea to simply use the definitions from the [original header file](https://github.com/WebAssembly/wasi-libc/blob/1b19fc65ad84b223876c50dd4fcd7d5a08c311dc/libc-top-half/musl/include/sys/socket.h) instead of copying them over?

Fixes #531