### PR TITLE
Fix fts build for shared library 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
       run: |
         make -j4 TARGET_TRIPLE=wasm32-wasi $MAKE_TARGETS
         make -j4 TARGET_TRIPLE=wasm32-wasip1 $MAKE_TARGETS
-        make -j4 TARGET_TRIPLE=wasm32-wasip2 $MAKE_TARGETS
+        make -j4 TARGET_TRIPLE=wasm32-wasip2 WASI_SNAPSHOT=p2 $MAKE_TARGETS
 
     - name: Build libc + threads
       # Only build the thread-capable wasi-libc in the latest supported Clang

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,11 +23,13 @@ jobs:
           - os: ubuntu-latest
             clang_version: 16.0.0
             llvm_asset_suffix: x86_64-linux-gnu-ubuntu-18.04
+            enable_pic: true
           - os: macos-latest
             clang_version: 15.0.7
             llvm_asset_suffix: x86_64-apple-darwin21.0
           - os: windows-latest
             clang_version: 16.0.0
+            enable_pic: true
     steps:
     - uses: actions/checkout@v4.1.7
       with:
@@ -88,12 +90,18 @@ jobs:
         echo "BUILD_LIBSETJMP=no" >> $GITHUB_ENV
       if: matrix.clang_version == '10.0.0'
 
+    - name: Enable PIC build for new LLVM
+      shell: bash
+      run: |
+        echo "MAKE_TARGETS=default libc_so" >> $GITHUB_ENV
+      if: matrix.enable_pic
+
     - name: Build libc
       shell: bash
       run: |
-        make -j4 TARGET_TRIPLE=wasm32-wasi
-        make -j4 TARGET_TRIPLE=wasm32-wasip1
-        make -j4 TARGET_TRIPLE=wasm32-wasip2 WASI_SNAPSHOT=p2
+        make -j4 TARGET_TRIPLE=wasm32-wasi $MAKE_TARGETS
+        make -j4 TARGET_TRIPLE=wasm32-wasip1 $MAKE_TARGETS
+        make -j4 TARGET_TRIPLE=wasm32-wasip2 $MAKE_TARGETS
 
     - name: Build libc + threads
       # Only build the thread-capable wasi-libc in the latest supported Clang

--- a/Makefile
+++ b/Makefile
@@ -619,6 +619,7 @@ BULK_MEMORY_SO_OBJS = $(patsubst %.o,%.pic.o,$(BULK_MEMORY_OBJS))
 DLMALLOC_SO_OBJS = $(patsubst %.o,%.pic.o,$(DLMALLOC_OBJS))
 LIBC_BOTTOM_HALF_ALL_SO_OBJS = $(patsubst %.o,%.pic.o,$(LIBC_BOTTOM_HALF_ALL_OBJS))
 LIBC_TOP_HALF_ALL_SO_OBJS = $(patsubst %.o,%.pic.o,$(LIBC_TOP_HALF_ALL_OBJS))
+FTS_SO_OBJS = $(patsubst %.o,%.pic.o,$(FTS_OBJS))
 
 PIC_OBJS = \
 	$(LIBC_SO_OBJS) \
@@ -635,7 +636,8 @@ PIC_OBJS = \
 	$(DLMALLOC_SO_OBJS) \
 	$(LIBC_BOTTOM_HALF_ALL_SO_OBJS) \
 	$(LIBC_TOP_HALF_ALL_SO_OBJS) \
-	$(LIBC_BOTTOM_HALF_CRT_OBJS)
+	$(LIBC_BOTTOM_HALF_CRT_OBJS) \
+	$(FTS_SO_OBJS)
 
 # TODO: Specify SDK version, e.g. libc.so.wasi-sdk-21, as SO_NAME once `wasm-ld`
 # supports it.
@@ -787,7 +789,7 @@ $(LIBC_TOP_HALF_ALL_OBJS) $(LIBC_TOP_HALF_ALL_SO_OBJS) $(MUSL_PRINTSCAN_LONG_DOU
     -Wno-dangling-else \
     -Wno-unknown-pragmas
 
-$(FTS_OBJS): CFLAGS += \
+$(FTS_OBJS) $(FTS_SO_OBJS): CFLAGS += \
     -I$(MUSL_FTS_SRC_DIR) \
     -I$(FTS_SRC_DIR) # for config.h
 


### PR DESCRIPTION
https://github.com/WebAssembly/wasi-libc/pull/522 did not include the necessary changes to the Makefile for libc_so build.
Additionally, updated CI to check `libc_so` build too to avoid future breakage.