### PR TITLE
test: fix shebang in run-test.sh

### DIFF
--- a/test/scripts/run-test.sh
+++ b/test/scripts/run-test.sh
@@ -1,4 +1,4 @@
-#/usr/bin/env bash
+#!/usr/bin/env bash
 
 # Run a previously built test, generating in `$DIR`:
 # - a `cmd.sh` script containing the actual command used to run the test in an


### PR DESCRIPTION
Follow-up to 2b853ff07903d7dc0af5bdc7b2d3c2e7a6892873

The wrong shebang caused `&>` to be interpreted as a background job