### PR TITLE
test: enable pthread-related libc-tests

### DIFF
--- a/test/src/libc-test/functional/pthread_cond.c
+++ b/test/src/libc-test/functional/pthread_cond.c
@@ -1,0 +1,5 @@
+//! filter.py(TARGET_TRIPLE): wasm32-wasip1-threads
+//! add-flags.py(CFLAGS): -I.
+//! add-flags.py(LDFLAGS): -Wl,--import-memory,--export-memory,--shared-memory,--max-memory=1073741824
+//! add-flags.py(RUN): --wasi threads
+#include "build/download/libc-test/src/functional/pthread_cond.c"

--- a/test/src/libc-test/functional/pthread_mutex.c
+++ b/test/src/libc-test/functional/pthread_mutex.c
@@ -1,0 +1,5 @@
+//! filter.py(TARGET_TRIPLE): wasm32-wasip1-threads
+//! add-flags.py(CFLAGS): -I.
+//! add-flags.py(LDFLAGS): -Wl,--import-memory,--export-memory,--shared-memory,--max-memory=1073741824
+//! add-flags.py(RUN): --wasi threads
+#include "build/download/libc-test/src/functional/pthread_mutex.c"

--- a/test/src/libc-test/functional/pthread_tsd.c
+++ b/test/src/libc-test/functional/pthread_tsd.c
@@ -1,0 +1,5 @@
+//! filter.py(TARGET_TRIPLE): wasm32-wasip1-threads
+//! add-flags.py(CFLAGS): -I.
+//! add-flags.py(LDFLAGS): -Wl,--import-memory,--export-memory,--shared-memory,--max-memory=1073741824
+//! add-flags.py(RUN): --wasi threads
+#include "build/download/libc-test/src/functional/pthread_tsd.c"


### PR DESCRIPTION
This change enables the pthread-related tests in the libc-test suite. The tests are enabled only for the `wasm32-wasip1-threads` target, which is the only target that supports threads at the moment.

The following pthread tests are still disabled:
- pthread_cancel-points.c
- pthread_cancel.c
- pthread_robust.c

This is a preparative change for https://github.com/swiftwasm/swift/issues/5598