### PR TITLE
Pin MacOS Github runner version in ci to MacOS 15

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-15, windows-latest]
         clang_version: [10.0.0]
         # use different LLVM versions among oses because of the lack of
         # official assets on github.
@@ -15,7 +15,7 @@ jobs:
           - os: ubuntu-22.04
             clang_version: 10.0.0
             llvm_asset_suffix: x86_64-linux-gnu-ubuntu-18.04
-          - os: macos-latest
+          - os: macos-15
             clang_version: 10.0.0
             llvm_asset_suffix: x86_64-apple-darwin
           - os: windows-latest
@@ -24,7 +24,7 @@ jobs:
             clang_version: 16.0.0
             llvm_asset_suffix: x86_64-linux-gnu-ubuntu-18.04
             enable_pic: true
-          - os: macos-latest
+          - os: macos-15
             clang_version: 15.0.7
             llvm_asset_suffix: x86_64-apple-darwin21.0
           - os: windows-latest
@@ -70,7 +70,7 @@ jobs:
         echo "CC=$CLANG_DIR/clang" >> $GITHUB_ENV
         echo "AR=$CLANG_DIR/llvm-ar" >> $GITHUB_ENV
         echo "NM=$CLANG_DIR/llvm-nm" >> $GITHUB_ENV
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-15'
 
     - name: Install LLVM tools (Linux)
       shell: bash
@@ -156,7 +156,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-15, windows-latest]
     steps:
     - uses: actions/checkout@v4.1.7
       with:
@@ -164,12 +164,12 @@ jobs:
     - name: Install Rust (rustup)
       shell: bash
       run: rustup update stable --no-self-update && rustup default stable
-      if: matrix.os != 'macos-latest'
+      if: matrix.os != 'macos-15'
     - name: Install Rust (macos)
       run: |
         curl https://sh.rustup.rs | sh -s -- -y
         echo "$HOME/.cargo/bin" >> $GITHUB_PATH
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-15'
     - run: cargo fetch
       working-directory: tools/wasi-headers
     - run: cargo build


### PR DESCRIPTION
Rather than using Macos-latest this makes the ci used a pinned version of Macos (set to the latest version available). This is so if you happen to have an issue with the MacOS build you know exactly which version of MacOS it is running, rather than having to dig into the ci, or Github runner documentation.