### PR TITLE
Update wasi-headers/WASI submodule to latest tagged version (v0.2.3)

### DIFF
--- a/tools/wasi-headers/Cargo.toml
+++ b/tools/wasi-headers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasi-headers"
-version = "0.0.1"
+version = "0.2.3"
 authors = ["Dan Gohman <sunfish@mozilla.com>", "Pat Hickey <phickey@fastly.com>"]
 license = "Apache-2.0"
 edition = "2018"


### PR DESCRIPTION
The WASI submodule references a commit which is 3 years old. This PR updates it to use the latest tagged version (v0.2.3) which was tagged 2 months ago.