### PR TITLE
Update MacOS-15 ci job building against llvm 15.0.7 to llvm 16.0.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
             llvm_asset_suffix: x86_64-linux-gnu-ubuntu-18.04
             enable_pic: true
           - os: macos-15
-            clang_version: 15.0.7
+            clang_version: 16.0.0
             llvm_asset_suffix: x86_64-apple-darwin21.0
           - os: windows-2025
             clang_version: 16.0.0


### PR DESCRIPTION
The ci jobs are either building against 10.0.0 or 16.0.0 except the MacOS job which builds against 15.0.7 . The PR updates the MacOS so it is consistent with the llvms used on the other operating systems.