### PR TITLE
[ci] Cancel outstanding workflows when new changes are added to PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,10 @@
 name: CI
 on: [push, pull_request]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   buildlibc:
     name: Build libc


### PR DESCRIPTION
If you submit a commit to a PR at the moment and then find an issue with that commit, and submit a new commit to fix the PR before the ci has finished then the ci runs fully for both commits. This PR makes sure that if a new commit is submitted the old ci run is cancelled. This should save on Github runner minutes, ensuring that the slow down across the organisation due to Github runner consumed minutes is less pronounced.