### PR TITLE
Preserve file timestamps when copying files in the install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -816,7 +816,7 @@ endif
 
 install: finish
 	mkdir -p "$(INSTALL_DIR)"
-	cp -r "$(SYSROOT)/lib" "$(SYSROOT)/share" "$(SYSROOT)/include" "$(INSTALL_DIR)"
+	cp -p -r "$(SYSROOT)/lib" "$(SYSROOT)/share" "$(SYSROOT)/include" "$(INSTALL_DIR)"
 
 DEFINED_SYMBOLS = $(SYSROOT_SHARE)/defined-symbols.txt
 UNDEFINED_SYMBOLS = $(SYSROOT_SHARE)/undefined-symbols.txt


### PR DESCRIPTION
This change makes it so that the timestamps of installed header files are only updated when the contents of the header files change. This change is beneficial for incremental builds of projects depending on wasi-libc. For example, the Swift project builds wasi-libc as part of its build process, and this change reduces the number of build products in the Swift build that are unnecessarily rebuilt.

This is a 2nd attempt of https://github.com/WebAssembly/wasi-libc/pull/530 but much simpler thanks to @abrown 's build work