### PR TITLE
Stop complaining on __wasm_extended_const__

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -913,6 +913,7 @@ check-symbols: $(STARTUP_FILES) libc
 	    -U__clang_version__ \
 	    -U__clang_literal_encoding__ \
 	    -U__clang_wide_literal_encoding__ \
+	    -U__wasm_extended_const__ \
 	    -U__wasm_mutable_globals__ \
 	    -U__wasm_sign_ext__ \
 	    -U__wasm_multivalue__ \


### PR DESCRIPTION
My motivation is to allow -mcpu=lime1 build with LLVM 20.

Note that extended-const is a part of lime1.
https://github.com/WebAssembly/tool-conventions/blob/main/Lime.md#lime1

cf. https://github.com/WebAssembly/wasi-sdk/pull/527