### PR TITLE
clang > 20.1.4 compat: unterminated strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -422,7 +422,8 @@ CFLAGS += -Wall -Wextra -Werror \
   -Wno-missing-braces \
   -Wno-ignored-pragmas \
   -Wno-unused-but-set-variable \
-  -Wno-unknown-warning-option
+  -Wno-unknown-warning-option \
+  -Wno-unterminated-string-initialization
 
 # Configure support for threads.
 ifeq ($(THREAD_MODEL), single)
@@ -738,7 +739,7 @@ $(INCLUDE_DIRS): $(ALL_POSSIBLE_HEADERS)
 	touch $@
 
 STARTUP_FILES := $(OBJDIR)/copy-startup-files.stamp
-$(STARTUP_FILES): $(INCLUDE_DIRS) $(LIBC_BOTTOM_HALF_CRT_OBJS) 
+$(STARTUP_FILES): $(INCLUDE_DIRS) $(LIBC_BOTTOM_HALF_CRT_OBJS)
 	#
 	# Install the startup files (crt1.o, etc.).
 	#


### PR DESCRIPTION
clang introduced a new warning (following gcc) for string initialization to char arrays that do not fit the null terminal. 

Introduced here: https://github.com/llvm/llvm-project/pull/137829
Included in LLVM version [LLVM 20.1.4](https://github.com/llvm/llvm-project/releases/tag/llvmorg-20.1.4)+

More detail:
-Wunterminated-string-initialization warns for c string literals that are written to a buffer too small to include a null terminator. This warning is also included in -Wextra which is enabled for wasi-libc and fails compilation due to -Werror.

Possible fixes:
 1. deactivate the warning
 2. add `__attribute__ ((nonstring))` to the three occurrences where this is a problem.

Chosen solution: 1.
Since the attribute is not available on older clang versions, it would trigger another warning there.

(included a small formatting change in the commit - pls ignore)