### PR TITLE
Optional SIMD strlen

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,6 +110,15 @@ jobs:
               TARGET_TRIPLE: wasm32-wasip1-threads
               THREAD_MODEL: posix
 
+          - name: Test SIMD
+            os: ubuntu-24.04
+            clang_version: 16
+            test: true
+            upload: wasm32-wasi
+            env:
+              MAKE_TARGETS: "no-check-symbols"
+              EXTRA_CFLAGS: "-O2 -DNDEBUG -msimd128 -mrelaxed-simd -mbulk-memory -D__wasilibc_simd_string"
+
     steps:
     - uses: actions/checkout@v4.1.7
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,7 +110,7 @@ jobs:
               TARGET_TRIPLE: wasm32-wasip1-threads
               THREAD_MODEL: posix
 
-          - name: Test SIMD
+          - name: Test wasm32-wasi-simd
             os: ubuntu-24.04
             clang_version: 16
             test: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -114,7 +114,7 @@ jobs:
             os: ubuntu-24.04
             clang_version: 16
             test: true
-            upload: wasm32-wasi
+            upload: wasm32-wasi-simd
             env:
               MAKE_TARGETS: "no-check-symbols"
               EXTRA_CFLAGS: "-O2 -DNDEBUG -msimd128 -mrelaxed-simd -mbulk-memory -D__wasilibc_simd_string"

--- a/Makefile
+++ b/Makefile
@@ -808,10 +808,12 @@ $(DUMMY_LIBS):
 	    $(AR) crs "$$lib"; \
 	done
 
-finish: $(STARTUP_FILES) libc $(DUMMY_LIBS)
+no-check-symbols: $(STARTUP_FILES) libc $(DUMMY_LIBS)
 	#
 	# The build succeeded! The generated sysroot is in $(SYSROOT).
 	#
+
+finish: no-check-symbols
 
 ifeq ($(LTO),no)
 # The check for defined and undefined symbols expects there to be a heap
@@ -1033,4 +1035,4 @@ clean:
 	$(RM) -r "$(OBJDIR)"
 	$(RM) -r "$(SYSROOT)"
 
-.PHONY: default libc libc_so finish install clean check-symbols bindings
+.PHONY: default libc libc_so finish install clean check-symbols no-check-symbols bindings

--- a/libc-top-half/musl/src/string/strlen.c
+++ b/libc-top-half/musl/src/string/strlen.c
@@ -26,6 +26,8 @@ size_t strlen(const char *s)
 			// At least one bit will be set, unless we cleared them.
 			// Knowing this helps the compiler.
 			__builtin_assume(mask || align);
+			// If the mask is zero because of alignment,
+			// it's as if we didn't find anything.
 			if (mask) {
 				// Find the offset of the first one bit (little-endian).
 				return (char *)v - s + __builtin_ctz(mask);

--- a/libc-top-half/musl/src/string/strlen.c
+++ b/libc-top-half/musl/src/string/strlen.c
@@ -25,13 +25,13 @@ size_t strlen(const char *s)
 		// Bitmask is slow on AArch64, all_true is much faster.
 		if (!wasm_i8x16_all_true(*v)) {
 			const v128_t cmp = wasm_i8x16_eq(*v, (v128_t){});
-			// Clear the bits corresponding to alignment (little-endian)
+			// Clear the bits corresponding to align (little-endian)
 			// so we can count trailing zeros.
 			int mask = wasm_i8x16_bitmask(cmp) >> align << align;
-			// At least one bit will be set, unless we cleared them.
-			// Knowing this helps the compiler.
+			// At least one bit will be set, unless align cleared them.
+			// Knowing this helps the compiler if it unrolls the loop.
 			__builtin_assume(mask || align);
-			// If the mask is zero because of alignment,
+			// If the mask became zero because of align,
 			// it's as if we didn't find anything.
 			if (mask) {
 				// Find the offset of the first one bit (little-endian).

--- a/libc-top-half/musl/src/string/strlen.c
+++ b/libc-top-half/musl/src/string/strlen.c
@@ -1,7 +1,10 @@
 #include <string.h>
 #include <stdint.h>
 #include <limits.h>
+
+#ifdef __wasm_simd128__
 #include <wasm_simd128.h>
+#endif
 
 #define ALIGN (sizeof(size_t))
 #define ONES ((size_t)-1/UCHAR_MAX)

--- a/libc-top-half/musl/src/string/strlen.c
+++ b/libc-top-half/musl/src/string/strlen.c
@@ -16,8 +16,10 @@ size_t strlen(const char *s)
 #if defined(__wasm_simd128__) && defined(__wasilibc_simd_string)
 	// strlen must stop as soon as it finds the terminator.
 	// Aligning ensures loads beyond the terminator are safe.
+	// Casting through uintptr_t makes this implementation-defined,
+	// rather than undefined behavior.
 	uintptr_t align = (uintptr_t)s % sizeof(v128_t);
-	const v128_t *v = (v128_t *)(s - align);
+	const v128_t *v = (v128_t *)((uintptr_t)s - align);
 
 	for (;;) {
 		// Bitmask is slow on AArch64, all_true is much faster.

--- a/libc-top-half/musl/src/string/strlen.c
+++ b/libc-top-half/musl/src/string/strlen.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <stdint.h>
 #include <limits.h>
+#include <wasm_simd128.h>
 
 #define ALIGN (sizeof(size_t))
 #define ONES ((size_t)-1/UCHAR_MAX)
@@ -9,6 +10,32 @@
 
 size_t strlen(const char *s)
 {
+#if defined(__wasm_simd128__) && defined(__wasilibc_simd_string)
+  // strlen must stop as soon as it finds the terminator.
+  // Aligning ensures loads beyond the terminator are safe.
+  uintptr_t align = (uintptr_t)s % sizeof(v128_t);
+  const v128_t *v = (v128_t *)(s - align);
+
+  for (;;) {
+    // Bitmask is slow on AArch64, all_true is much faster.
+    if (!wasm_i8x16_all_true(*v)) {
+      const v128_t cmp = wasm_i8x16_eq(*v, (v128_t){});
+      // Clear the bits corresponding to alignment (little-endian)
+      // so we can count trailing zeros.
+      int mask = wasm_i8x16_bitmask(cmp) >> align << align;
+      // At least one bit will be set, unless we cleared them.
+      // Knowing this helps the compiler.
+      __builtin_assume(mask || align);
+      if (mask) {
+        // Find the offset of the first one bit (little-endian).
+        return (char *)v - s + __builtin_ctz(mask);
+      }
+    }
+    align = 0;
+    v++;
+  }
+#endif
+
 	const char *a = s;
 #ifdef __GNUC__
 	typedef size_t __attribute__((__may_alias__)) word;

--- a/test/src/misc/strlen.c
+++ b/test/src/misc/strlen.c
@@ -17,15 +17,20 @@ int main(void) {
 
   for (size_t length = 0; length < 64; length++) {
     for (size_t alignment = 0; alignment < 24; alignment++) {
+      // Create a string with the given length, at a pointer with the given
+      // aligment. Using the offset LIMIT - PAGESIZE - 8 means many strings will
+      // straddle a (Wasm, and likely OS) page boundary.
       char *ptr = LIMIT - PAGESIZE - 8 + alignment;
       memset(LIMIT - 2 * PAGESIZE, 0, 2 * PAGESIZE);
       memset(ptr, 5, length);
       test(ptr, length);
 
+      // Make sure we're not fooled by non-zero characters prior to the string.
       ptr[-1] = 5;
       test(ptr, length);
     }
 
+    // Ensure we never read past the end of memory.
     char *ptr = LIMIT - length - 1;
     memset(LIMIT - 2 * PAGESIZE, 0, 2 * PAGESIZE);
     memset(ptr, 5, length);

--- a/test/src/misc/strlen.c
+++ b/test/src/misc/strlen.c
@@ -1,7 +1,5 @@
 //! add-flags.py(LDFLAGS): -Wl,--stack-first -Wl,--initial-memory=327680
 
-static char *const LIMIT = (char *)327680;
-
 #include <__macro_PAGESIZE.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -15,6 +13,8 @@ void test(char *ptr, size_t want) {
 }
 
 int main(void) {
+  char *const LIMIT = (char *)(__builtin_wasm_memory_size(0) * PAGESIZE);
+
   for (size_t length = 0; length < 64; length++) {
     for (size_t alignment = 0; alignment < 24; alignment++) {
       char *ptr = LIMIT - PAGESIZE + alignment;

--- a/test/src/misc/strlen.c
+++ b/test/src/misc/strlen.c
@@ -1,7 +1,6 @@
 //! add-flags.py(LDFLAGS): -Wl,--stack-first -Wl,--initial-memory=327680
 
 #include <__macro_PAGESIZE.h>
-#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -18,8 +17,8 @@ int main(void) {
   for (size_t length = 0; length < 64; length++) {
     for (size_t alignment = 0; alignment < 24; alignment++) {
       // Create a string with the given length, at a pointer with the given
-      // aligment. Using the offset LIMIT - PAGESIZE - 8 means many strings will
-      // straddle a (Wasm, and likely OS) page boundary.
+      // alignment. Using the offset LIMIT - PAGESIZE - 8 means many strings
+      // will straddle a (Wasm, and likely OS) page boundary.
       char *ptr = LIMIT - PAGESIZE - 8 + alignment;
       memset(LIMIT - 2 * PAGESIZE, 0, 2 * PAGESIZE);
       memset(ptr, 5, length);

--- a/test/src/misc/strlen.c
+++ b/test/src/misc/strlen.c
@@ -17,7 +17,7 @@ int main(void) {
 
   for (size_t length = 0; length < 64; length++) {
     for (size_t alignment = 0; alignment < 24; alignment++) {
-      char *ptr = LIMIT - PAGESIZE + alignment;
+      char *ptr = LIMIT - PAGESIZE - 8 + alignment;
       memset(LIMIT - 2 * PAGESIZE, 0, 2 * PAGESIZE);
       memset(ptr, 5, length);
       test(ptr, length);

--- a/test/src/misc/strlen.c
+++ b/test/src/misc/strlen.c
@@ -1,0 +1,36 @@
+//! add-flags.py(LDFLAGS): -Wl,--stack-first -Wl,--initial-memory=327680
+
+static char *const LIMIT = (char *)327680;
+
+#include <__macro_PAGESIZE.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+void test(char *ptr, size_t want) {
+  size_t got = strlen(ptr);
+  if (got != want) {
+    printf("strlen(%p) = %lu, want %lu\n", ptr, got, want);
+  }
+}
+
+int main(void) {
+  for (size_t length = 0; length < 64; length++) {
+    for (size_t alignment = 0; alignment < 24; alignment++) {
+      char *ptr = LIMIT - PAGESIZE + alignment;
+      memset(LIMIT - 2 * PAGESIZE, 0, 2 * PAGESIZE);
+      memset(ptr, 5, length);
+      test(ptr, length);
+
+      ptr[-1] = 5;
+      test(ptr, length);
+    }
+
+    char *ptr = LIMIT - length - 1;
+    memset(LIMIT - 2 * PAGESIZE, 0, 2 * PAGESIZE);
+    memset(ptr, 5, length);
+    test(ptr, length);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This is a potential first step at upstreaming #580 piecemeal.

Chose `strlen` as it's already covered by tests. It's also one of the simplest (easiest to review) implementations.

Built and tested with:
```sh
CC=[PATH_TO]/wasi-sdk-25.0-x86_64-linux/bin/clang \
  EXTRA_CFLAGS="-O2 -DNDEBUG -msimd128 -mbulk-memory -D__wasilibc_simd_string" make
(cd test ; CC=[PATH_TO]/wasi-sdk-25.0-x86_64-linux/bin/clang make )
```