### PR TITLE
Skip `pthread_cond_busywait` test in browser tests

### DIFF
--- a/test/scripts/browser-test/harness.mjs
+++ b/test/scripts/browser-test/harness.mjs
@@ -21,6 +21,7 @@ import { chromium } from 'playwright';
 const SKIP_TESTS = [
     // "poll_oneoff" can't be implemented in the browser
     "libc-test/functional/pthread_cond",
+    "libc-test/functional/pthread_cond_busywait",
     // atomic.wait32 can't be executed on the main thread
     "libc-test/functional/pthread_mutex",
     "libc-test/functional/pthread_tsd",


### PR DESCRIPTION
The `pthread_cond` test uses `nanosleep` which eventually calls `poll_oneoff` but `@bjorn3/browser_wasi_shim` does not implement it. So we skip the test for now, but we will revisit it later once https://github.com/bjorn3/browser_wasi_shim/pull/88 is merged.