### PR TITLE
Revert "Skip pthread_cond_busywait test in browser tests (#589)"

### DIFF
--- a/test/scripts/browser-test/harness.mjs
+++ b/test/scripts/browser-test/harness.mjs
@@ -21,7 +21,6 @@ import { chromium } from 'playwright';
 const SKIP_TESTS = [
     // "poll_oneoff" can't be implemented in the browser
     "libc-test/functional/pthread_cond",
-    "libc-test/functional/pthread_cond_busywait",
     // atomic.wait32 can't be executed on the main thread
     "libc-test/functional/pthread_mutex",
     "libc-test/functional/pthread_tsd",

--- a/test/scripts/browser-test/run-test.mjs
+++ b/test/scripts/browser-test/run-test.mjs
@@ -1,7 +1,7 @@
 /**
  * This script is served by `harness.mjs` and runs in the browser.
  */
-import { WASI, File, OpenFile, ConsoleStdout, PreopenDirectory } from 'https://cdn.jsdelivr.net/npm/@bjorn3/browser_wasi_shim@0.3.0/+esm'
+import { WASI, File, OpenFile, ConsoleStdout, PreopenDirectory } from 'https://cdn.jsdelivr.net/npm/@bjorn3/browser_wasi_shim@0.4.2/+esm'
 import { polyfill } from 'https://cdn.jsdelivr.net/npm/wasm-imports-parser@1.0.4/polyfill.js/+esm';
 
 /**


### PR DESCRIPTION
Update @bjorn3/browser_wasi_shim to version 0.4.2. This release includes a limited polyfill for `poll_oneoff`, which is necessary for the `pthread_cond` test to pass in the browser. https://github.com/bjorn3/browser_wasi_shim/pull/88