### PR TITLE
Fix build and tests for wasm32-wasip2 target

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -57,4 +57,10 @@ runs:
         echo "CC=clang-$v" >> $GITHUB_ENV
         echo "AR=llvm-ar-$v" >> $GITHUB_ENV
         echo "NM=llvm-nm-$v" >> $GITHUB_ENV
+        # Note: wasm-component-ld is only needed for Linux because
+        # currently, wasm32-wasip2 is only tested on Linux. If that changes,
+        # this step will have to be added to the other targets.
+        curl -fsSLO https://github.com/bytecodealliance/wasm-component-ld/releases/download/v0.5.15/wasm-component-ld-v0.5.15-x86_64-linux.tar.gz
+        tar xzf wasm-component-ld-v0.5.15-x86_64-linux.tar.gz
+        echo "$(pwd)/wasm-component-ld-v0.5.15-x86_64-linux" >> $GITHUB_PATH
       if: runner.os == 'Linux'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,12 +22,12 @@ jobs:
           # wasi-libc builds on these platforms by default.
           - name: Build on Linux x86_64
             os: ubuntu-24.04
-            clang_version: 16
-            upload: linux-x86_64-clang-16
+            clang_version: 19
+            upload: linux-x86_64-clang-19
           - name: Build on Linux aarch64
             os: ubuntu-24.04-arm
-            clang_version: 16
-            upload: linux-aarch64-clang-16
+            clang_version: 19
+            upload: linux-aarch64-clang-19
           - name: Build on macOS aarch64
             os: macos-15
             clang_version: 15.0.7
@@ -35,8 +35,8 @@ jobs:
             upload: macos-clang-15
           - name: Build on Windows x86_64
             os: windows-2025
-            clang_version: 16.0.0
-            upload: windows-clang-16
+            clang_version: 20.1.8
+            upload: windows-clang-20
 
           # Other versions of LLVM
           - name: Build with LLVM 11
@@ -45,12 +45,6 @@ jobs:
             upload: linux-x86_64-clang-11
             env:
               BUILD_LIBSETJMP: no
-          - name: Build with LLVM 19
-            os: ubuntu-24.04
-            clang_version: 19
-            upload: linux-x86_64-clang-19
-            env:
-              MAKE_TARGETS: "default libc_so"
           - name: Build with LLVM 18
             os: ubuntu-24.04
             clang_version: 18
@@ -58,7 +52,7 @@ jobs:
             env:
               MAKE_TARGETS: "default libc_so"
 
-          # Test various combinations of targets triples.
+          # Test various combinations of target triples.
           #
           # Configuration here can happen through `env` which is inherited to
           # jobs below. For now this only runs tests on Linux with Clang 16,
@@ -67,7 +61,7 @@ jobs:
           # ensure the PIC build works.
           - name: Test wasm32-wasi
             os: ubuntu-24.04
-            clang_version: 16
+            clang_version: 19
             test: true
             upload: wasm32-wasi
             env:
@@ -75,7 +69,7 @@ jobs:
               MAKE_TARGETS: "default libc_so"
           - name: Test wasm32-wasip1
             os: ubuntu-24.04
-            clang_version: 16
+            clang_version: 19
             test: true
             upload: wasm32-wasip1
             env:
@@ -83,7 +77,7 @@ jobs:
               MAKE_TARGETS: "default libc_so"
           - name: Test wasm32-wasip2
             os: ubuntu-24.04
-            clang_version: 16
+            clang_version: 19
             test: true
             upload: wasm32-wasip2
             env:
@@ -92,7 +86,7 @@ jobs:
               MAKE_TARGETS: "default libc_so"
           - name: Test wasm32-wasi-threads
             os: ubuntu-24.04
-            clang_version: 16
+            clang_version: 19
             test: true
             upload: wasm32-wasi-threads
             env:
@@ -100,7 +94,7 @@ jobs:
               THREAD_MODEL: posix
           - name: Test wasm32-wasip1-threads
             os: ubuntu-24.04
-            clang_version: 16
+            clang_version: 19
             test: true
             upload: wasm32-wasip1-threads
             env:
@@ -108,14 +102,14 @@ jobs:
               THREAD_MODEL: posix
           - name: Test wasm32-wasip1 in V8
             os: ubuntu-24.04
-            clang_version: 16
+            clang_version: 19
             test: true
             test_with_v8: true
             env:
               TARGET_TRIPLE: wasm32-wasip1
           - name: Test wasm32-wasip1-threads in V8
             os: ubuntu-24.04
-            clang_version: 16
+            clang_version: 19
             test: true
             test_with_v8: true
             env:
@@ -124,7 +118,7 @@ jobs:
 
           - name: Test wasm32-wasi-simd
             os: ubuntu-24.04
-            clang_version: 16
+            clang_version: 19
             test: true
             upload: wasm32-wasi-simd
             env:

--- a/test/Makefile
+++ b/test/Makefile
@@ -14,6 +14,15 @@ test: run
 # Decide which target to build for and which libc to use.
 TARGET_TRIPLE ?= wasm32-wasi
 
+# See comment in ../Makefile
+ifeq ($(THREAD_MODEL), posix)
+TARGET_TRIPLE = wasm32-wasip1-threads
+endif
+
+ifeq ($(WASI_SNAPSHOT), p2)
+TARGET_TRIPLE = wasm32-wasip2
+endif
+
 # Setup various paths used by the tests.
 OBJDIR ?= build/$(TARGET_TRIPLE)
 DOWNDIR ?= build/download
@@ -134,6 +143,13 @@ BUILTINS_STAMP := $(OBJDIR)/builtins.stamp
 $(BUILTINS_STAMP):
 	make -C .. builtins
 	touch $@
+
+# For wasip2, we want clang to generate a core module rather than a component,
+# because `wasm-tools component new` is called subsequently and it expects
+# a core module.
+ifeq ($(TARGET_TRIPLE), wasm32-wasip2)
+LDFLAGS += -Wl,--skip-wit-component
+endif
 
 # Build up all the `*.wasm.o` object files; these are the same regardless of
 # whether we're building core modules or components.


### PR DESCRIPTION
Trying to build wasi-libc for the `wasm32-wasip2` target and run the tests, I noticed a few issues:

- `TARGET_TRIPLE` was being used before definition, in the definition of `OBJDIR`.
- The ?= operator instead of = was being used to set `TARGET_TRIPLE` to `wasm32-wasip2`.
This always left the target as `wasm32-wasi`, since it was defined to that in a previous line.
- `builtins` wasn't being built by default, so building the tests would fail because it was unable to find `libclang_rt.builtins.a`.
- `make test` didn't take the`WASI_SNAPSHOT` variable into consideration.
- When building tests, `clang --target=wasm32-wasip2` was building a P2 component,
which caused the subsequent `wasm-tools component new` to fail because the input
was already a component.

This PR fixes these issues. Now I'm able to run the tests with `WASI_SNAPSHOT=p2`.