### PR TITLE
Port _Exit() to use wasip2 method

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/stdlib/_Exit.c
+++ b/libc-bottom-half/cloudlibc/src/libc/stdlib/_Exit.c
@@ -2,13 +2,22 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
+#ifdef __wasilibc_use_wasip2
+#include <wasi/wasip2.h>
+#else
 #include <wasi/api.h>
+#endif
 #include <_/cdefs.h>
 #include <stdnoreturn.h>
 #include <unistd.h>
 
 noreturn void _Exit(int status) {
+#ifdef __wasilibc_use_wasip2
+  exit_result_void_void_t exit_status = { .is_err = status != 0 };
+  exit_exit(&exit_status);
+#else
   __wasi_proc_exit(status);
+#endif
 }
 
 __strong_reference(_Exit, _exit);

--- a/libc-bottom-half/crt/crt1-command.c
+++ b/libc-bottom-half/crt/crt1-command.c
@@ -2,7 +2,11 @@
 #include <stdatomic.h>
 extern void __wasi_init_tp(void);
 #endif
+#ifdef __wasilibc_use_wasip2
+#include <wasi/wasip2.h>
+#else
 #include <wasi/api.h>
+#endif
 extern void __wasm_call_ctors(void);
 extern int __main_void(void);
 extern void __wasm_call_dtors(void);
@@ -47,7 +51,14 @@ void _start(void) {
 
     // If main exited successfully, just return, otherwise call
     // `__wasi_proc_exit`.
+#ifdef __wasilibc_use_wasip2
+    if (r != 0) {
+        exit_result_void_void_t status = { .is_err = true };
+        exit_exit(&status);
+    }
+#else
     if (r != 0) {
         __wasi_proc_exit(r);
     }
+#endif
 }

--- a/libc-bottom-half/headers/public/wasi/wasip2.h
+++ b/libc-bottom-half/headers/public/wasi/wasip2.h
@@ -1084,7 +1084,7 @@ extern bool environment_initial_cwd(wasip2_string_t *ret);
 
 // Imported Functions from `wasi:cli/exit@0.2.0`
 // Exit the current instance and any linked instances.
-extern void exit_exit(exit_result_void_void_t *status);
+_Noreturn extern void exit_exit(exit_result_void_void_t *status);
 
 // Imported Functions from `wasi:io/error@0.2.0`
 // Returns a string that is suitable to assist humans in debugging

--- a/libc-bottom-half/headers/public/wasi/wasip2.h
+++ b/libc-bottom-half/headers/public/wasi/wasip2.h
@@ -1084,6 +1084,9 @@ extern bool environment_initial_cwd(wasip2_string_t *ret);
 
 // Imported Functions from `wasi:cli/exit@0.2.0`
 // Exit the current instance and any linked instances.
+// NOTE: This file has been manually edited to add the _Noreturn
+// annotation on exit_exit(). If the file is re-generated, this
+// annotation will have to be re-added.
 _Noreturn extern void exit_exit(exit_result_void_void_t *status);
 
 // Imported Functions from `wasi:io/error@0.2.0`

--- a/libc-bottom-half/sources/wasip2.c
+++ b/libc-bottom-half/sources/wasip2.c
@@ -11,6 +11,9 @@ extern void __wasm_import_environment_get_arguments(int32_t);
 __attribute__((__import_module__("wasi:cli/environment@0.2.0"), __import_name__("initial-cwd")))
 extern void __wasm_import_environment_initial_cwd(int32_t);
 
+// NOTE: This file has been manually edited to add the _Noreturn
+// annotation on __wasm_import_exit_exit(). If the file is re-generated, this
+// annotation will have to be re-added.
 __attribute__((__import_module__("wasi:cli/exit@0.2.0"), __import_name__("exit")))
 _Noreturn extern void __wasm_import_exit_exit(int32_t);
 

--- a/libc-bottom-half/sources/wasip2.c
+++ b/libc-bottom-half/sources/wasip2.c
@@ -12,7 +12,7 @@ __attribute__((__import_module__("wasi:cli/environment@0.2.0"), __import_name__(
 extern void __wasm_import_environment_initial_cwd(int32_t);
 
 __attribute__((__import_module__("wasi:cli/exit@0.2.0"), __import_name__("exit")))
-extern void __wasm_import_exit_exit(int32_t);
+_Noreturn extern void __wasm_import_exit_exit(int32_t);
 
 __attribute__((__import_module__("wasi:io/error@0.2.0"), __import_name__("[method]error.to-debug-string")))
 extern void __wasm_import_io_error_method_error_to_debug_string(int32_t, int32_t);
@@ -1068,7 +1068,7 @@ bool environment_initial_cwd(wasip2_string_t *ret) {
   return option.is_some;
 }
 
-void exit_exit(exit_result_void_void_t *status) {
+_Noreturn void exit_exit(exit_result_void_void_t *status) {
   int32_t result;
   if ((*status).is_err) {
     result = 1;


### PR DESCRIPTION
WARNING: This commit edits the auto-generated files wasip2.h and wasip2.c to add the _Noreturn attribute to `exit_exit`.