### PR TITLE
Disable build symbol check by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -136,7 +136,7 @@ jobs:
         llvm_asset_suffix: ${{ matrix.llvm_asset_suffix }}
 
     - name: Build libc
-      run: make -j4 $MAKE_TARGETS
+      run: make -j4 $MAKE_TARGETS CHECK_SYMBOLS=yes
 
     - name: Download Test dependencies
       if: matrix.test

--- a/Makefile
+++ b/Makefile
@@ -881,13 +881,8 @@ no-check-symbols: $(STARTUP_FILES) libc $(DUMMY_LIBS)
 
 finish: no-check-symbols
 
-ifeq ($(LTO),no)
-# The check for defined and undefined symbols expects there to be a heap
-# allocator (providing malloc, calloc, free, etc). Skip this step if the build
-# is done without a malloc implementation.
-ifneq ($(MALLOC_IMPL),none)
+ifeq ($(CHECK_SYMBOLS),yes)
 finish: check-symbols
-endif
 endif
 
 install: finish


### PR DESCRIPTION
I've personally found this to mostly be an annoyance having it on-by-default. This means that changing flags can often break the build and it also means that externally using a different LLVM can often break the build too. In the interest of making the build less brittle this disables the check by default.

To avoid losing the benefit of having this check, however, CI opts-in to enabling this check for all tests. That should mean that we're still testing in this repository, but integrations elsewhere don't have to worry about it.