### PR TITLE
Allow calls to descriptor_table_update() to initialize descriptor table

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/dirent/fdopendir.c
+++ b/libc-bottom-half/cloudlibc/src/libc/dirent/fdopendir.c
@@ -56,8 +56,10 @@ DIR *fdopendir(int fd) {
   stream_info.directory_file_handle = file_handle;
   new_entry.directory_stream_info = stream_info;
   int new_fd = -1;
-  descriptor_table_update(dirp->fd, new_entry);
-
+  if (!descriptor_table_update(dirp->fd, new_entry)) {
+    errno = EBADF;
+    return NULL;
+  }
   dirp->cookie = __WASI_DIRCOOKIE_START;
   dirp->buffer_processed = 0;
   dirp->buffer_size = DIRENT_DEFAULT_BUFFER_SIZE;

--- a/libc-bottom-half/cloudlibc/src/libc/fcntl/openat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/fcntl/openat.c
@@ -110,8 +110,10 @@ int __wasilibc_nocwd_openat_nomode(int fd, const char *path, int oflag) {
   new_entry.file.readable = ((oflag & O_RDONLY) != 0);
   new_entry.file.writable = ((oflag & O_WRONLY) != 0);
   new_entry.file.file_handle = filesystem_borrow_descriptor(new_handle);
-  descriptor_table_insert(new_entry, &new_fd);
-
+  if (!descriptor_table_insert(new_entry, &new_fd)) {
+    errno = ENOMEM;
+    return -1;
+  }
   // Return the new file descriptor from the table
   return new_fd;
 #else

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/lseek.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/lseek.c
@@ -37,7 +37,10 @@ off_t __lseek(int fildes, off_t offset, int whence) {
   off_t offset_to_use = 0;
   // Look up a stream for fildes
   descriptor_table_entry_t *entry;
-  descriptor_table_get_ref(fildes, &entry);
+  if (!descriptor_table_get_ref(fildes, &entry)) {
+    errno = EBADF;
+    return -1;
+  }
   if (entry->tag == DESCRIPTOR_TABLE_ENTRY_FILE_STREAM) {
     // Find the offset relative to the beginning of the file
     // The offset is always *added*: either to 0, the current

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/read.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/read.c
@@ -27,7 +27,10 @@ ssize_t read(int fildes, void *buf, size_t nbyte) {
 
   // Translate the file descriptor to an internal handle
   descriptor_table_entry_t* entry = 0;
-  descriptor_table_get_ref(fildes, &entry);
+  if (!descriptor_table_get_ref(fildes, &entry)) {
+    errno = EBADF;
+    return -1;
+  }
   streams_borrow_input_stream_t input_stream;
   if (entry->tag == DESCRIPTOR_TABLE_ENTRY_FILE_HANDLE) {
     // File's input stream hasn't been opened yet
@@ -73,7 +76,10 @@ ssize_t read(int fildes, void *buf, size_t nbyte) {
     new_entry.stream.file_info.readable = entry->file.readable;
     new_entry.stream.file_info.writable = entry->file.writable;
     new_entry.stream.file_info.file_handle = entry->file.file_handle;
-    descriptor_table_update(fildes, new_entry);
+    if (!descriptor_table_update(fildes, new_entry)) {
+      errno = ENOMEM;
+      return -1;
+    }
   } else if (entry->tag == DESCRIPTOR_TABLE_ENTRY_FILE_STREAM) {
       if (!entry->stream.file_info.readable) {
         errno = EBADF;
@@ -112,7 +118,10 @@ ssize_t read(int fildes, void *buf, size_t nbyte) {
   wasip2_list_u8_free(&contents);
 
   // Update the offset
-  descriptor_table_get_ref(fildes, &entry);
+  if (!descriptor_table_get_ref(fildes, &entry)) {
+    errno = EBADF;
+    return -1;
+  }
   if (entry->tag == DESCRIPTOR_TABLE_ENTRY_FILE_STREAM) {
     entry->stream.offset += contents.len;
   } else {

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/read.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/read.c
@@ -18,8 +18,12 @@ ssize_t read(int fildes, void *buf, size_t nbyte) {
   bool ok = false;
 
   // Check for stdin
-  if (fildes == 0)
-      init_stdin();
+  if (fildes == 0) {
+      if (!init_stdin()) {
+        errno = EINVAL;
+        return -1;
+      }
+  }
 
   // Translate the file descriptor to an internal handle
   descriptor_table_entry_t* entry = 0;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/write.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/write.c
@@ -25,10 +25,18 @@ ssize_t write(int fildes, const void *buf, size_t nbyte) {
   descriptor_table_entry_t* entry = 0;
 
   // Check for stdout/stderr
-  if (fildes == 1)
-    init_stdout();
-  else if (fildes == 2)
-    init_stderr();
+  if (fildes == 1) {
+    if (!init_stdout()) {
+      errno = EINVAL;
+      return -1;
+    }
+  }
+  else if (fildes == 2) {
+    if (!init_stderr()) {
+      errno = EINVAL;
+      return -1;
+    }
+  }
 
   // Translate the file descriptor to an internal handle
   descriptor_table_get_ref(fildes, &entry);

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/write.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/write.c
@@ -39,7 +39,10 @@ ssize_t write(int fildes, const void *buf, size_t nbyte) {
   }
 
   // Translate the file descriptor to an internal handle
-  descriptor_table_get_ref(fildes, &entry);
+  if (!descriptor_table_get_ref(fildes, &entry)) {
+      errno = EBADF;
+      return -1;
+  }
   if (entry->tag == DESCRIPTOR_TABLE_ENTRY_FILE_HANDLE) {
     create_new_stream = true;
 
@@ -131,7 +134,10 @@ ssize_t write(int fildes, const void *buf, size_t nbyte) {
     new_entry.stream.file_info.writable = entry->file.writable;
     new_entry.stream.file_info.file_handle = entry->file.file_handle;
     new_entry.tag = DESCRIPTOR_TABLE_ENTRY_FILE_STREAM;
-    descriptor_table_update(fildes, new_entry);
+    if (!descriptor_table_update(fildes, new_entry)) {
+      errno = ENOMEM;
+      return -1;
+    }
   }
 
   ok = streams_method_output_stream_blocking_flush(output_stream,

--- a/libc-bottom-half/headers/private/wasi/file_utils.h
+++ b/libc-bottom-half/headers/private/wasi/file_utils.h
@@ -55,7 +55,8 @@ static void remove_and_drop_directory_stream(int fd) {
 
   if (entry->tag == DESCRIPTOR_TABLE_ENTRY_DIRECTORY_STREAM) {
     filesystem_directory_entry_stream_drop_own(entry->directory_stream_info.directory_stream);
-    descriptor_table_remove(fd, entry);
+    if (!descriptor_table_remove(fd, entry))
+      return;
   }
 }
 

--- a/libc-bottom-half/sources/__wasilibc_tell.c
+++ b/libc-bottom-half/sources/__wasilibc_tell.c
@@ -11,7 +11,10 @@ off_t __wasilibc_tell(int fildes) {
 #ifdef __wasilibc_use_wasip2
   // Look up a stream for fildes
   descriptor_table_entry_t *entry;
-  descriptor_table_get_ref(fildes, &entry);
+  if (!descriptor_table_get_ref(fildes, &entry)) {
+    errno = EBADF;
+    return -1;
+  }
 
   // Return the current offset in the stream
   if (entry->tag == DESCRIPTOR_TABLE_ENTRY_FILE_STREAM) {

--- a/libc-bottom-half/sources/descriptor_table.c
+++ b/libc-bottom-half/sources/descriptor_table.c
@@ -216,10 +216,8 @@ bool descriptor_table_get_ref(int fd, descriptor_table_entry_t **entry)
         return get(fd, entry, &global_table);
 }
 
-bool descriptor_table_update(int fd, descriptor_table_entry_t entry) {
-        if (!global_table.entries)
-            return false;
-
+bool descriptor_table_update(int fd, descriptor_table_entry_t entry)
+{
         return insert(entry, fd, &global_table, true);
 }
 


### PR DESCRIPTION
This was breaking reads/writes to stdin/stdout/stderr.

Also check return values from init_{stdin, stdout, stderr}, although this may not help much since the return values from printf()/etc. aren't usually checked.