### PR TITLE
descriptor table: hash the fd rather than the identity function

### DIFF
--- a/libc-bottom-half/sources/descriptor_table.c
+++ b/libc-bottom-half/sources/descriptor_table.c
@@ -55,8 +55,7 @@ static int next_fd = 3;
 
 static size_t keyhash(int key)
 {
-        // TODO: use a hash function here
-        return key;
+        return (size_t)key * 2654435769U;
 }
 
 static int resize(size_t nel, descriptor_table_t *table)


### PR DESCRIPTION
Use a trivial Knuth's multiplicative hash, that works perfectly for sequential file descriptors.