### PR TITLE
poll_wasip1: ignore entries with no events requested

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/poll/poll.c
+++ b/libc-bottom-half/cloudlibc/src/libc/poll/poll.c
@@ -39,7 +39,8 @@ static int poll_wasip1(struct pollfd *fds, size_t nfds, int timeout) {
     // As entries are decomposed into separate read/write subscriptions,
     // we cannot detect POLLERR, POLLHUP and POLLNVAL if POLLRDNORM and
     // POLLWRNORM are not specified. Disallow this for now.
-    if (!created_events) {
+    // Ignore fd entries that have no events requested.
+    if (!created_events && pollfd->events != 0) {
       errno = ENOSYS;
       return -1;
     }


### PR DESCRIPTION
OpenSSH allocates a pollfd structure for all of its channels, but doesn't request events for all of them all the time.  If it wants to check a subset, it clears events, but keeps nfds at the max. This causes the wasip1 implementation to incorrectly abort as it assumes that if POLLRDNORM & POLLWRNORM didn't match, it must be due to requesting unsupported events, and then it errors out with ENOSYS.  Simply ignore the case where no events are requested and it all works fine.