### PR TITLE
Handle '.' and '..' correctly in scandir() and opendir()

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/dirent/fdopendir.c
+++ b/libc-bottom-half/cloudlibc/src/libc/dirent/fdopendir.c
@@ -54,6 +54,7 @@ DIR *fdopendir(int fd) {
   directory_stream_entry_t stream_info;
   stream_info.directory_stream = result;
   stream_info.directory_file_handle = file_handle;
+  stream_info.directory_state = DIRECTORY_STATE_FILE;
   new_entry.directory_stream_info = stream_info;
   int new_fd = -1;
   if (!descriptor_table_update(dirp->fd, new_entry)) {

--- a/libc-bottom-half/headers/private/wasi/descriptor_table.h
+++ b/libc-bottom-half/headers/private/wasi/descriptor_table.h
@@ -106,12 +106,23 @@ typedef struct {
         udp_socket_state_t state;
 } udp_socket_t;
 
+typedef enum read_directory_state_t {
+        DIRECTORY_STATE_FILE,
+        DIRECTORY_STATE_RETURNED_DOT,
+        DIRECTORY_STATE_RETURNED_DOT_DOT
+} read_directory_state_t;
+
 typedef struct {
 // Stream for contents of directory
         filesystem_own_directory_entry_stream_t directory_stream;
 // File handle for the directory being listed
 // (so that metadata hashes can be accessed).
         filesystem_borrow_descriptor_t directory_file_handle;
+// State that reflects whether . and .. have been handled yet;
+// this is used by readdir() since each call handles a single
+// directory entry, and this state needs to be maintained across
+// calls
+        read_directory_state_t directory_state;
 } directory_stream_entry_t;
 
 // Stream representing an open file.

--- a/test/src/misc/opendir.c
+++ b/test/src/misc/opendir.c
@@ -1,0 +1,55 @@
+//! add-flags.py(RUN): --dir fs::foo
+//! add-flags.py(ARGS): foo
+
+#include <errno.h>
+#include <stdbool.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <dirent.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include "test.h"
+
+#define TEST(c) do { \
+	errno = 0; \
+	if (!(c)) \
+		t_error("%s failed (errno = %d)\n", #c, errno); \
+} while(0)
+
+int main(int argc, char **argv)
+{
+    TEST(argc == 2);
+
+    DIR *dir = opendir(argv[1]);
+    TEST(dir != NULL);
+
+    int count = 0;
+    bool saw_dot = false;
+    bool saw_dot_dot = false;
+    for (;; count += 1) {
+      struct dirent *ent = readdir(dir);
+      if (ent == NULL) {
+        if (errno == 0)
+          break;
+        TEST(ent != NULL);
+      }
+
+      if (strcmp(ent->d_name, ".") == 0) {
+        TEST(ent->d_type == DT_DIR);
+        saw_dot = true;
+      }
+      else if (strcmp(ent->d_name, "..") == 0) {
+        TEST(ent->d_type == DT_DIR);
+        saw_dot_dot = true;
+      }
+    }
+    TEST(count == 2);
+    TEST(saw_dot);
+    TEST(saw_dot_dot);
+
+    TEST(closedir(dir) == 0);
+
+    return t_status;
+}


### PR DESCRIPTION
Previously, opendir() and scandir() weren't returning the directory
entries for '.' and '..'. This also fixes the setting of directory
entry types.
