### PR TITLE
Add a sockets test with an accept loop in the server

### DIFF
--- a/libc-bottom-half/sources/poll-wasip2.c
+++ b/libc-bottom-half/sources/poll-wasip2.c
@@ -23,6 +23,8 @@ int poll_wasip2(struct pollfd *fds, size_t nfds, int timeout)
         for (size_t i = 0; i < nfds; ++i) {
                 struct pollfd *pollfd = fds + i;
                 descriptor_table_entry_t *entry;
+                if (pollfd->fd < 0)
+                    continue;
                 if (descriptor_table_get_ref(pollfd->fd, &entry)) {
                         switch (entry->tag) {
                         case DESCRIPTOR_TABLE_ENTRY_TCP_SOCKET: {

--- a/test/scripts/run-test.sh
+++ b/test/scripts/run-test.sh
@@ -14,7 +14,7 @@ ENGINE="${ENGINE:-wasmtime}"
 
 # Run the client/server sockets test, which requires a client and server
 # running in separate processes
-run_sockets_test() {
+run_sockets_test_simple() {
     # Args are the same for client and server
     cd $DIR
     server_wasm=`echo $WASM | sed -e 's/client/server/g'`
@@ -38,12 +38,56 @@ run_sockets_test() {
     [ $test_result -eq 0 ] || echo "Test failed" >> output.log
 }
 
+# Run the client/server sockets test, which requires one server
+# and multiple clients running in separate processes
+CLIENTS=10
+run_sockets_test_multiple() {
+    # Args are the same for client and server
+    cd $DIR
+    server_wasm=`echo $WASM | sed -e 's/client/server/g'`
+    echo "$ENV $ENGINE $RUN $server_wasm $ARGS" > server_cmd.sh
+    chmod +x server_cmd.sh
+    # Start the server
+    ./server_cmd.sh &> server_output.log &
+    PID=$!
+    [ $? -ne -1 ] || (echo "Failed to start server $server_wasm" && exit 1)
+    echo "$ENV $ENGINE $RUN $WASM $ARGS" > cmd.sh
+    chmod +x cmd.sh
+    # Allow time for the server to start
+    sleep 1
+    # Start the clients
+    pids=()
+    for ((i = 0; i < CLIENTS; i++)); do
+        ./cmd.sh &> output"$i".log &
+        pids+=( $! )
+    done
+    ANY_FAILURES=0
+    for ((i = 0; i < CLIENTS; i++)); do
+        wait ${pids[i]}
+        if [ $? -ne 0 ]; then
+           ANY_FAILURES=1
+        fi
+    done
+    # Server normally exits on its own, but kill it in case the test failed
+    if [ ps -p $PID > /dev/null 2>&1 ]; then
+        kill -9 $PID
+    fi
+    [ $ANY_FAILURES -eq 0 ] || echo "Test failed" >> output.log
+}
+
 testname=$(basename $WASM)
 if [ $testname == "sockets-server.component.wasm" ]; then
     exit 0
 fi
+if [ $testname == "sockets-multiple-server.component.wasm" ]; then
+    exit 0
+fi
 if [ $testname == "sockets-client.component.wasm" ]; then
-    run_sockets_test
+    run_sockets_test_simple
+    exit $?
+fi
+if [ $testname == "sockets-multiple-client.component.wasm" ]; then
+    run_sockets_test_multiple
     exit $?
 fi
 cd $DIR

--- a/test/src/misc/sockets-multiple-client.c
+++ b/test/src/misc/sockets-multiple-client.c
@@ -1,0 +1,70 @@
+//! filter.py(TARGET_TRIPLE): wasm32-wasip2
+//! add-flags.py(RUN): --wasi=inherit-network=y
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include "test.h"
+
+#define TEST(c) do { \
+	errno = 0; \
+	if (!(c)) \
+		t_error("%s failed (errno = %d)\n", #c, errno); \
+} while(0)
+
+int BUFSIZE = 256;
+
+// See sockets-multiple-server.c -- must be running already as a separate executable
+void test_tcp_client() {
+    // Prepare server socket
+    int server_port = 4001;
+
+    // Prepare client socket
+    // Use blocking sockets
+    int socket_fd = socket(AF_INET, SOCK_STREAM, 0);
+    TEST(socket_fd != -1);
+
+    // Prepare sockaddr_in for client
+    struct sockaddr_in sockaddr_in;
+    sockaddr_in.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+    sockaddr_in.sin_family = AF_INET;
+    sockaddr_in.sin_port = htons(server_port);
+
+    // Connect from client
+    // Generate a random number to test that multiple clients each receive
+    // the correct response
+    int32_t number = 0;
+    getentropy(&number, sizeof(int32_t));
+    char message[BUFSIZE];
+    sprintf(message, "%d", number);
+    int len = strlen(message);
+    char client_buffer[BUFSIZE];
+
+    TEST(connect(socket_fd, (struct sockaddr*)&sockaddr_in, sizeof(sockaddr_in)) != -1);
+
+    // Client writes a message to server
+    TEST(send(socket_fd, message, len, 0) == len);
+
+    // Client reads from server
+    int32_t bytes_received = recv(socket_fd, client_buffer, len, 0);
+    TEST(bytes_received == len);
+
+    // Message received should be the same as message sent
+    TEST(strcmp(message, client_buffer) == 0);
+
+    // Shut down client
+    close(socket_fd);
+}
+
+int main(void)
+{
+    test_tcp_client();
+
+    return t_status;
+}

--- a/test/src/misc/sockets-multiple-server.c
+++ b/test/src/misc/sockets-multiple-server.c
@@ -1,0 +1,97 @@
+//! filter.py(TARGET_TRIPLE): wasm32-wasip2
+//! add-flags.py(RUN): --wasi=inherit-network=y
+#include <errno.h>
+#include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <netdb.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include "poll.h"
+#include "test.h"
+
+#define TEST(c) do { \
+	errno = 0; \
+	if (!(c)) \
+		t_error("%s failed (errno = %d)\n", #c, errno); \
+} while(0)
+
+int BUFSIZE = 256;
+int EXPECTED_CONNECTIONS = 10;
+int TIMEOUT = 100;
+
+size_t respond_to_client(int client_fd) {
+    char buffer[BUFSIZE];
+    size_t total_bytes_read = 0, bytes_read = 0;
+    while ((bytes_read = recv(client_fd, buffer, BUFSIZE, 0)) > 0) {
+        total_bytes_read += bytes_read;
+        // Echo back the data received from the client
+        send(client_fd, buffer, bytes_read, 0);
+    }
+    return total_bytes_read;
+}
+
+void run_tcp_server() {
+    // Prepare server socket
+    int server_port = 4001;
+    // Use blocking sockets
+    int server_socket_fd = socket(AF_INET, SOCK_STREAM, 0);
+
+    // Bind server to socket
+    struct sockaddr_in server_address;
+    server_address.sin_family = AF_INET;
+    server_address.sin_addr.s_addr = htonl(INADDR_ANY);
+    server_address.sin_port = htons(server_port);
+    TEST(bind(server_socket_fd, (struct sockaddr*)&server_address, sizeof(server_address)) != -1);
+
+    // Listen on socket
+    socklen_t client_len = sizeof(struct sockaddr_in);
+    int client_socket_fd;
+    struct sockaddr_in client_address;
+    int32_t bytes_read = 0, total_bytes_read = 0;
+    TEST(listen(server_socket_fd, 1) != -1);
+
+    // Server accepts connection
+    struct pollfd client_fds[EXPECTED_CONNECTIONS];
+
+    // Wait until a fixed number of clients connect
+    for (size_t i = 0; i < EXPECTED_CONNECTIONS; i++) {
+        client_socket_fd = accept(server_socket_fd, (struct sockaddr*)&client_address, &client_len);
+        TEST(client_socket_fd != -1);
+        client_fds[i].fd = client_socket_fd;
+        client_fds[i].events &= POLLIN;
+    }
+
+    // Poll on the array of client file descriptors and respond to
+    // any that are ready
+    size_t connections = 0;
+    while (poll(client_fds, EXPECTED_CONNECTIONS, TIMEOUT) != 0) {
+        for (int i = 0; i < EXPECTED_CONNECTIONS; i++) {
+            if (client_fds[i].revents | POLLIN) {
+                total_bytes_read += respond_to_client(client_fds[i].fd);
+                // If fd is negative, revents will be set to 0 on the next call
+                client_fds[i].fd = ~client_fds[i].fd;
+            }
+        }
+    }
+
+    TEST(total_bytes_read > 0);
+
+    for (size_t i = 0; i < EXPECTED_CONNECTIONS; i++) {
+        // fd was set to the complement of itself, so
+        // it needs to be complemented again
+        close(~client_fds[i].fd);
+    }
+    close(server_socket_fd);
+}
+
+int main()
+{
+    run_tcp_server();
+
+    return t_status;
+}


### PR DESCRIPTION
In the test case, the server loops until a fixed number of connections are made, then calls poll() on all the file descriptors for the connections until all of them have been responded to.

Also, fix poll_wasip2() to handle negative file descriptors correctly