### PR TITLE
Fix two resource leak bugs (wasip2)

### DIFF
--- a/libc-bottom-half/headers/private/wasi/file_utils.h
+++ b/libc-bottom-half/headers/private/wasi/file_utils.h
@@ -68,8 +68,11 @@ static void remove_and_drop_directory_stream(int fd) {
 
   if (entry->tag == DESCRIPTOR_TABLE_ENTRY_DIRECTORY_STREAM) {
     filesystem_directory_entry_stream_drop_own(entry->directory_stream_info.directory_stream);
-    if (!descriptor_table_remove(fd, entry))
-      return;
+    filesystem_borrow_descriptor_t file_handle = entry->directory_stream_info.directory_file_handle;
+    entry->tag = DESCRIPTOR_TABLE_ENTRY_FILE_HANDLE;
+    entry->file.file_handle = file_handle;
+    entry->file.readable = true;
+    entry->file.writable = false;
   }
 }
 


### PR DESCRIPTION
* scandir() wasn't closing its file descriptors
* The remove_and_drop_directory_stream() function that's used in a few places was deleting the file descriptor from the table so that the underlying file handle wouldn't be closed