### PR TITLE
wasip2: Don't `strdup` strings as arguments

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/fcntl/openat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/fcntl/openat.c
@@ -84,8 +84,7 @@ int __wasilibc_nocwd_openat_nomode(int fd, const char *path, int oflag) {
   }
 
   // Construct a WASI string for the path
-  wasip2_string_t path2;
-  wasip2_string_dup(&path2, path);
+  wasip2_string_t path2 = wasip2_string_temp(path);
 
   // Open the file, yielding a new handle
   filesystem_own_descriptor_t new_handle;
@@ -97,7 +96,6 @@ int __wasilibc_nocwd_openat_nomode(int fd, const char *path, int oflag) {
                                                  fs_flags,
                                                  &new_handle,
                                                  &error_code);
-  wasip2_string_free(&path2);
   if (!ok) {
     translate_error(error_code);
     return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/stdio/renameat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/stdio/renameat.c
@@ -28,10 +28,9 @@ int __wasilibc_nocwd_renameat(int oldfd, const char *old, int newfd, const char 
     return -1;
   }
 
-  // Copy the strings into WASI strings
-  wasip2_string_t old_path, new_path;
-  wasip2_string_dup(&old_path, old);
-  wasip2_string_dup(&new_path, new);
+  // Convert the strings into WASI strings
+  wasip2_string_t old_path = wasip2_string_temp(old);
+  wasip2_string_t new_path = wasip2_string_temp(new);
 
   // Rename the file
   filesystem_error_code_t error_code;
@@ -40,8 +39,6 @@ int __wasilibc_nocwd_renameat(int oldfd, const char *old, int newfd, const char 
                                                    new_file_handle,
                                                    &new_path,
                                                    &error_code);
-  wasip2_string_free(&old_path);
-  wasip2_string_free(&new_path);
   if (!ok) {
     translate_error(error_code);
     return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/sys/stat/fstatat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/stat/fstatat.c
@@ -28,9 +28,8 @@ int __wasilibc_nocwd_fstatat(int fd, const char *restrict path, struct stat *res
     return -1;
   }
 
-  // Copy the string into a Wasm string
-  wasip2_string_t path_wasm_string;
-  wasip2_string_dup(&path_wasm_string, path);
+  // Convert the string into a Wasm string
+  wasip2_string_t path_wasm_string = wasip2_string_temp(path);
 
   // Get the metadata hash for this file
   filesystem_metadata_hash_value_t metadata;
@@ -58,7 +57,6 @@ int __wasilibc_nocwd_fstatat(int fd, const char *restrict path, struct stat *res
                                                           &path_wasm_string,
                                                           &internal_stat,
                                                           &error);
-  wasip2_string_free(&path_wasm_string);
   if (!stat_result) {
     translate_error(error);
     return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/sys/stat/mkdirat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/stat/mkdirat.c
@@ -24,12 +24,10 @@ int __wasilibc_nocwd_mkdirat_nomode(int fd, const char *path) {
 
   // Create the directory
   filesystem_error_code_t error;
-  wasip2_string_t path2;
-  wasip2_string_dup(&path2, path);
+  wasip2_string_t path2 = wasip2_string_temp(path);
   bool ok = filesystem_method_descriptor_create_directory_at(file_handle,
-                                                               &path2,
-                                                               &error);
-  wasip2_string_free(&path2);
+                                                             &path2,
+                                                             &error);
   if (!ok) {
     translate_error(error);
     return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/sys/stat/utimensat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/stat/utimensat.c
@@ -50,9 +50,8 @@ int __wasilibc_nocwd_utimensat(int fd, const char *path, const struct timespec t
   if ((flag & AT_SYMLINK_NOFOLLOW) == 0)
     lookup_flags |= __WASI_LOOKUPFLAGS_SYMLINK_FOLLOW;
 
-  // Copy the string into a Wasm string
-  wasip2_string_t path_wasm_string;
-  wasip2_string_dup(&path_wasm_string, path);
+  // Convert the string into a Wasm string
+  wasip2_string_t path_wasm_string = wasip2_string_temp(path);
 
   // Perform system call.
   filesystem_error_code_t error;
@@ -62,7 +61,6 @@ int __wasilibc_nocwd_utimensat(int fd, const char *path, const struct timespec t
                                                                     &new_timestamp_atim,
                                                                     &new_timestamp_mtim,
                                                                     &error);
-  wasip2_string_free(&path_wasm_string);
   if (!set_times_result) {
     translate_error(error);
     return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/faccessat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/faccessat.c
@@ -31,9 +31,8 @@ int __wasilibc_nocwd_faccessat(int fd, const char *path, int amode, int flag) {
     return -1;
   }
 
-  // Convert the path to a WASI string
-  wasip2_string_t wasi_path;
-  wasip2_string_dup(&wasi_path, path);
+  // Convert the string into a WASI string
+  wasip2_string_t wasi_path = wasip2_string_temp(path);
 
   // Call stat() to check if the file exists
   filesystem_descriptor_stat_t stat_result;
@@ -43,7 +42,6 @@ int __wasilibc_nocwd_faccessat(int fd, const char *path, int amode, int flag) {
                                                  &wasi_path,
                                                  &stat_result,
                                                  &error_code);
-  wasip2_string_free(&wasi_path);
   if (!ok) {
     translate_error(error_code);
     return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/linkat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/linkat.c
@@ -27,10 +27,9 @@ int __wasilibc_nocwd_linkat(int fd1, const char *path1, int fd2, const char *pat
     return -1;
   }
 
-  // Create WASI strings for the paths
-  wasip2_string_t path1_wasi, path2_wasi;
-  wasip2_string_dup(&path1_wasi, path1);
-  wasip2_string_dup(&path2_wasi, path2);
+  // Convert the strings into WASI strings
+  wasip2_string_t path1_wasi = wasip2_string_temp(path1);
+  wasip2_string_t path2_wasi = wasip2_string_temp(path2);
 
   // Create the link
   filesystem_error_code_t error_code;
@@ -40,9 +39,6 @@ int __wasilibc_nocwd_linkat(int fd1, const char *path1, int fd2, const char *pat
                                                  file_handle2,
                                                  &path2_wasi,
                                                  &error_code);
-  wasip2_string_free(&path1_wasi);
-  wasip2_string_free(&path2_wasi);
-
   if (!ok) {
     translate_error(error_code);
     return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/symlinkat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/symlinkat.c
@@ -23,11 +23,9 @@ int __wasilibc_nocwd_symlinkat(const char *path1, int fd, const char *path2) {
     return -1;
   }
 
-  // Construct WASI string for the paths
-  wasip2_string_t path1_wasi;
-  wasip2_string_dup(&path1_wasi, path1);
-  wasip2_string_t path2_wasi;
-  wasip2_string_dup(&path2_wasi, path2);
+  // Convert the paths into WASI paths
+  wasip2_string_t path1_wasi = wasip2_string_temp(path1);
+  wasip2_string_t path2_wasi = wasip2_string_temp(path2);
 
   // Construct the link
   filesystem_error_code_t error_code;
@@ -36,9 +34,6 @@ int __wasilibc_nocwd_symlinkat(const char *path1, int fd, const char *path2) {
                                                     &path1_wasi,
                                                     &path2_wasi,
                                                     &error_code);
-  wasip2_string_free(&path1_wasi);
-  wasip2_string_free(&path2_wasi);
-
   // Check for errors
   if (!ok) {
     translate_error(error_code);

--- a/libc-bottom-half/headers/private/wasi/file_utils.h
+++ b/libc-bottom-half/headers/private/wasi/file_utils.h
@@ -5,6 +5,16 @@
 #include <wasi/descriptor_table.h>
 #include <dirent.h>
 
+// Converts the C string `s` into a WASI string.
+//
+// The returned `wasip2_string_t` should not be deallocated or free'd, and it
+// can only be used while `s` is also valid.
+static wasip2_string_t wasip2_string_temp(const char *s) {
+  wasip2_string_t ret;
+  wasip2_string_set(&ret, (char*) s);
+  return ret;
+}
+
 // Succeed only if fd is bound to a file handle in the descriptor table
 static bool fd_to_file_handle(int fd, filesystem_borrow_descriptor_t* result) {
   descriptor_table_entry_t* entry = 0;

--- a/libc-bottom-half/sources/__wasilibc_rmdirat.c
+++ b/libc-bottom-half/sources/__wasilibc_rmdirat.c
@@ -1,6 +1,7 @@
 #ifdef __wasilibc_use_wasip2
 #include <wasi/wasip2.h>
 #include <wasi/descriptor_table.h>
+#include <wasi/file_utils.h>
 #include <common/errors.h>
 #else
 #include <wasi/api.h>
@@ -28,13 +29,11 @@ int __wasilibc_nocwd___wasilibc_rmdirat(int fd, const char *path) {
   }
 
   // Create a WASI string for the path
-  wasip2_string_t wasi_path;
-  wasip2_string_dup(&wasi_path, path);
+  wasip2_string_t wasi_path = wasip2_string_temp(path);
   filesystem_error_code_t error_code;
 
   // Remove the directory
   bool ok = filesystem_method_descriptor_remove_directory_at(file_handle, &wasi_path, &error_code);
-  wasip2_string_free(&wasi_path);
   if (!ok) {
     translate_error(error_code);
     return -1;

--- a/libc-bottom-half/sources/__wasilibc_unlinkat.c
+++ b/libc-bottom-half/sources/__wasilibc_unlinkat.c
@@ -1,6 +1,7 @@
 #ifdef __wasilibc_use_wasip2
 #include <wasi/wasip2.h>
 #include <wasi/descriptor_table.h>
+#include <wasi/file_utils.h>
 #include <common/errors.h>
 #else
 #include <wasi/api.h>
@@ -29,15 +30,13 @@ int __wasilibc_nocwd___wasilibc_unlinkat(int fd, const char *path) {
   }
 
   // Create a Wasm string from the path
-  wasip2_string_t wasi_path;
-  wasip2_string_dup(&wasi_path, path);
+  wasip2_string_t wasi_path = wasip2_string_temp(path);
 
   // Unlink the file
   filesystem_error_code_t error_code;
   bool ok = filesystem_method_descriptor_unlink_file_at(entry->file.file_handle,
                                                         &wasi_path,
                                                         &error_code);
-  wasip2_string_free(&wasi_path);
   if (!ok) {
     translate_error(error_code);
     return -1;


### PR DESCRIPTION
There's no need to copy the string and it can be used as-is in its utf-8 representation in `char*`, so no need to copy it elsewhere to deallocate after the import call.