### PR TITLE
wasip2: Remove `*_is_initialized` for pollables

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/unistd/lseek.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/lseek.c
@@ -72,10 +72,14 @@ off_t __lseek(int fildes, off_t offset, int whence) {
     }
     }
     // Drop the existing streams
-    if (entry->stream.read_pollable_is_initialized)
+    if (entry->stream.read_pollable.__handle != 0) {
       poll_pollable_drop_own(entry->stream.read_pollable);
-    if (entry->stream.write_pollable_is_initialized)
+      entry->stream.read_pollable.__handle = 0;
+    }
+    if (entry->stream.write_pollable.__handle != 0) {
       poll_pollable_drop_own(entry->stream.write_pollable);
+      entry->stream.write_pollable.__handle = 0;
+    }
     if (entry->stream.file_info.readable)
       streams_input_stream_drop_borrow(entry->stream.read_stream);
     if (entry->stream.file_info.writable)
@@ -112,8 +116,6 @@ off_t __lseek(int fildes, off_t offset, int whence) {
       entry->stream.write_stream = streams_borrow_output_stream(new_stream);
     }
 
-    entry->stream.read_pollable_is_initialized = false;
-    entry->stream.write_pollable_is_initialized = false;
     // Update offset
     entry->stream.offset = offset_to_use;
   } else {

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/read.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/read.c
@@ -70,8 +70,8 @@ ssize_t read(int fildes, void *buf, size_t nbyte) {
     // for this file
     new_entry.tag = DESCRIPTOR_TABLE_ENTRY_FILE_STREAM;
     new_entry.stream.read_stream = input_stream;
-    new_entry.stream.read_pollable_is_initialized = false;
-    new_entry.stream.write_pollable_is_initialized = false;
+    new_entry.stream.read_pollable.__handle = false;
+    new_entry.stream.write_pollable.__handle = false;
     new_entry.stream.offset = 0;
     new_entry.stream.file_info.readable = entry->file.readable;
     new_entry.stream.file_info.writable = entry->file.writable;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/write.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/write.c
@@ -64,9 +64,8 @@ ssize_t write(int fildes, const void *buf, size_t nbyte) {
       return -1;
     }
     output_stream = entry->stream.write_stream;
-    if (!entry->stream.write_pollable_is_initialized) {
+    if (entry->stream.write_pollable.__handle == 0) {
       pollable = entry->stream.write_pollable = streams_method_output_stream_subscribe(output_stream);
-      entry->stream.write_pollable_is_initialized = true;
     } else
       pollable = entry->stream.write_pollable;
   } else {
@@ -126,8 +125,7 @@ ssize_t write(int fildes, const void *buf, size_t nbyte) {
       new_entry.stream.read_stream = streams_borrow_input_stream(read_stream);
     }
     new_entry.stream.write_pollable = pollable;
-    new_entry.stream.read_pollable_is_initialized = false;
-    new_entry.stream.write_pollable_is_initialized = true;
+    new_entry.stream.read_pollable.__handle = 0;
     new_entry.stream.write_stream = output_stream;
     new_entry.stream.offset = contents.len;
     new_entry.stream.file_info.readable = entry->file.readable;

--- a/libc-bottom-half/headers/private/wasi/descriptor_table.h
+++ b/libc-bottom-half/headers/private/wasi/descriptor_table.h
@@ -144,8 +144,6 @@ typedef struct {
         // Used for checking readiness to read/write to stream. Lazily initialized
         streams_own_pollable_t read_pollable;
         streams_own_pollable_t write_pollable;
-        bool read_pollable_is_initialized;
-        bool write_pollable_is_initialized;
         // When the stream is closed, the caller should
         // replace this entry in the table with the file handle
         file_t file_info;

--- a/libc-bottom-half/headers/private/wasi/file_utils.h
+++ b/libc-bottom-half/headers/private/wasi/file_utils.h
@@ -87,8 +87,8 @@ static bool init_stdin() {
       entry.tag = DESCRIPTOR_TABLE_ENTRY_FILE_STREAM;
       entry.stream.read_stream = streams_borrow_input_stream(stdin_get_stdin());
       entry.stream.offset = 0;
-      entry.stream.read_pollable_is_initialized = false;
-      entry.stream.write_pollable_is_initialized = false;
+      entry.stream.read_pollable.__handle = 0;
+      entry.stream.write_pollable.__handle = 0;
       entry.stream.file_info.readable = true;
       entry.stream.file_info.writable = false;
       // entry.stream.file_info.file_handle is uninitialized, but it will never be used
@@ -106,8 +106,8 @@ static bool init_stdout() {
       entry.tag = DESCRIPTOR_TABLE_ENTRY_FILE_STREAM;
       entry.stream.write_stream = streams_borrow_output_stream(stdout_get_stdout());
       entry.stream.offset = 0;
-      entry.stream.read_pollable_is_initialized = false;
-      entry.stream.write_pollable_is_initialized = false;
+      entry.stream.read_pollable.__handle = 0;
+      entry.stream.write_pollable.__handle = 0;
       entry.stream.file_info.readable = false;
       entry.stream.file_info.writable = true;
       // entry.stream.file_info.file_handle is uninitialized, but it will never be used
@@ -125,8 +125,8 @@ static bool init_stderr() {
       entry.tag = DESCRIPTOR_TABLE_ENTRY_FILE_STREAM;
       entry.stream.write_stream = streams_borrow_output_stream(stderr_get_stderr());
       entry.stream.offset = 0;
-      entry.stream.read_pollable_is_initialized = false;
-      entry.stream.write_pollable_is_initialized = false;
+      entry.stream.read_pollable.__handle = 0;
+      entry.stream.write_pollable.__handle = 0;
       entry.stream.file_info.readable = false;
       entry.stream.file_info.writable = true;
       // entry.stream.file_info.file_handle is uninitialized, but it will never be used

--- a/libc-bottom-half/sources/__wasilibc_fd_renumber.c
+++ b/libc-bottom-half/sources/__wasilibc_fd_renumber.c
@@ -122,9 +122,9 @@ int close(int fd) {
             drop_directory_stream(entry.directory_stream_info.directory_stream);
             break;
         case DESCRIPTOR_TABLE_ENTRY_FILE_STREAM:
-            if (entry.stream.read_pollable_is_initialized)
+            if (entry.stream.read_pollable.__handle != 0)
                 poll_pollable_drop_own(entry.stream.read_pollable);
-            if (entry.stream.write_pollable_is_initialized)
+            if (entry.stream.write_pollable.__handle != 0)
                 poll_pollable_drop_own(entry.stream.write_pollable);
             if (entry.stream.file_info.readable)
                 streams_input_stream_drop_borrow(entry.stream.read_stream);

--- a/libc-bottom-half/sources/poll-wasip2.c
+++ b/libc-bottom-half/sources/poll-wasip2.c
@@ -151,9 +151,8 @@ int poll_wasip2(struct pollfd *fds, size_t nfds, int timeout)
                                     return -1;
                                 }
                                 streams_own_pollable_t input_stream_pollable = stream->read_pollable;
-                                if (!stream->read_pollable_is_initialized) {
+                                if (stream->read_pollable.__handle == 0) {
                                     input_stream_pollable = stream->read_pollable = streams_method_input_stream_subscribe(stream->read_stream);
-                                    stream->read_pollable_is_initialized = true;
                                 }
                                 states[state_index++] = (state_t) {
                                     .pollable = input_stream_pollable,
@@ -168,9 +167,8 @@ int poll_wasip2(struct pollfd *fds, size_t nfds, int timeout)
                                     return -1;
                                 }
                                 streams_own_pollable_t output_stream_pollable = stream->write_pollable;
-                                if (!stream->write_pollable_is_initialized) {
+                                if (stream->write_pollable.__handle == 0) {
                                     output_stream_pollable = stream->write_pollable = streams_method_output_stream_subscribe(stream->write_stream);
-                                    stream->write_pollable_is_initialized = true;
                                 }
                                 states[state_index++] = (state_t){
                                     .pollable = output_stream_pollable,


### PR DESCRIPTION
Take advantage of the fact that handles are never 0 to store a 0-value to represent uninitialized and then a nonzero value is initialized.