### PR TITLE
wasip2: Don't store pollables in descriptor table

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/unistd/lseek.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/lseek.c
@@ -72,10 +72,6 @@ off_t __lseek(int fildes, off_t offset, int whence) {
     }
     }
     // Drop the existing streams
-    if (entry->stream.read_pollable_is_initialized)
-      poll_pollable_drop_own(entry->stream.read_pollable);
-    if (entry->stream.write_pollable_is_initialized)
-      poll_pollable_drop_own(entry->stream.write_pollable);
     if (entry->stream.file_info.readable)
       streams_input_stream_drop_borrow(entry->stream.read_stream);
     if (entry->stream.file_info.writable)
@@ -112,8 +108,6 @@ off_t __lseek(int fildes, off_t offset, int whence) {
       entry->stream.write_stream = streams_borrow_output_stream(new_stream);
     }
 
-    entry->stream.read_pollable_is_initialized = false;
-    entry->stream.write_pollable_is_initialized = false;
     // Update offset
     entry->stream.offset = offset_to_use;
   } else {

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/read.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/read.c
@@ -70,8 +70,6 @@ ssize_t read(int fildes, void *buf, size_t nbyte) {
     // for this file
     new_entry.tag = DESCRIPTOR_TABLE_ENTRY_FILE_STREAM;
     new_entry.stream.read_stream = input_stream;
-    new_entry.stream.read_pollable_is_initialized = false;
-    new_entry.stream.write_pollable_is_initialized = false;
     new_entry.stream.offset = 0;
     new_entry.stream.file_info.readable = entry->file.readable;
     new_entry.stream.file_info.writable = entry->file.writable;

--- a/libc-bottom-half/headers/private/wasi/descriptor_table.h
+++ b/libc-bottom-half/headers/private/wasi/descriptor_table.h
@@ -18,9 +18,7 @@ typedef struct {
 
 typedef struct {
         streams_own_input_stream_t input;
-        poll_own_pollable_t input_pollable;
         streams_own_output_stream_t output;
-        poll_own_pollable_t output_pollable;
 } tcp_socket_state_connected_t;
 
 typedef struct {
@@ -49,7 +47,6 @@ typedef struct {
 
 typedef struct {
         tcp_own_tcp_socket_t socket;
-        poll_own_pollable_t socket_pollable;
         bool blocking;
         bool fake_nodelay;
         bool fake_reuseaddr;
@@ -61,9 +58,7 @@ typedef struct {
 
 typedef struct {
         udp_own_incoming_datagram_stream_t incoming;
-        poll_own_pollable_t incoming_pollable;
         udp_own_outgoing_datagram_stream_t outgoing;
-        poll_own_pollable_t outgoing_pollable;
 } udp_socket_streams_t;
 
 typedef struct {
@@ -102,7 +97,6 @@ typedef struct {
 
 typedef struct {
         udp_own_udp_socket_t socket;
-        poll_own_pollable_t socket_pollable;
         bool blocking;
         network_ip_address_family_t family;
         udp_socket_state_t state;
@@ -141,11 +135,6 @@ typedef struct {
         streams_borrow_output_stream_t write_stream;
         // Current position in stream, relative to the beginning of the *file*, measured in bytes
         off_t offset;
-        // Used for checking readiness to read/write to stream. Lazily initialized
-        streams_own_pollable_t read_pollable;
-        streams_own_pollable_t write_pollable;
-        bool read_pollable_is_initialized;
-        bool write_pollable_is_initialized;
         // When the stream is closed, the caller should
         // replace this entry in the table with the file handle
         file_t file_info;

--- a/libc-bottom-half/headers/private/wasi/file_utils.h
+++ b/libc-bottom-half/headers/private/wasi/file_utils.h
@@ -87,8 +87,6 @@ static bool init_stdin() {
       entry.tag = DESCRIPTOR_TABLE_ENTRY_FILE_STREAM;
       entry.stream.read_stream = streams_borrow_input_stream(stdin_get_stdin());
       entry.stream.offset = 0;
-      entry.stream.read_pollable_is_initialized = false;
-      entry.stream.write_pollable_is_initialized = false;
       entry.stream.file_info.readable = true;
       entry.stream.file_info.writable = false;
       // entry.stream.file_info.file_handle is uninitialized, but it will never be used
@@ -106,8 +104,6 @@ static bool init_stdout() {
       entry.tag = DESCRIPTOR_TABLE_ENTRY_FILE_STREAM;
       entry.stream.write_stream = streams_borrow_output_stream(stdout_get_stdout());
       entry.stream.offset = 0;
-      entry.stream.read_pollable_is_initialized = false;
-      entry.stream.write_pollable_is_initialized = false;
       entry.stream.file_info.readable = false;
       entry.stream.file_info.writable = true;
       // entry.stream.file_info.file_handle is uninitialized, but it will never be used
@@ -125,8 +121,6 @@ static bool init_stderr() {
       entry.tag = DESCRIPTOR_TABLE_ENTRY_FILE_STREAM;
       entry.stream.write_stream = streams_borrow_output_stream(stderr_get_stderr());
       entry.stream.offset = 0;
-      entry.stream.read_pollable_is_initialized = false;
-      entry.stream.write_pollable_is_initialized = false;
       entry.stream.file_info.readable = false;
       entry.stream.file_info.writable = true;
       // entry.stream.file_info.file_handle is uninitialized, but it will never be used

--- a/libc-bottom-half/sources/__wasilibc_fd_renumber.c
+++ b/libc-bottom-half/sources/__wasilibc_fd_renumber.c
@@ -45,8 +45,6 @@ void drop_tcp_socket(tcp_socket_t socket) {
     case TCP_SOCKET_STATE_CONNECTED: {
         tcp_socket_state_connected_t connection = socket.state.connected;
 
-        poll_pollable_drop_own(connection.input_pollable);
-        poll_pollable_drop_own(connection.output_pollable);
         streams_input_stream_drop_own(connection.input);
         streams_output_stream_drop_own(connection.output);
         break;
@@ -54,13 +52,10 @@ void drop_tcp_socket(tcp_socket_t socket) {
     default: /* unreachable */ abort();
     }
 
-    poll_pollable_drop_own(socket.socket_pollable);
     tcp_tcp_socket_drop_own(socket.socket);
 }
 
 void drop_udp_socket_streams(udp_socket_streams_t streams) {
-    poll_pollable_drop_own(streams.incoming_pollable);
-    poll_pollable_drop_own(streams.outgoing_pollable);
     udp_incoming_datagram_stream_drop_own(streams.incoming);
     udp_outgoing_datagram_stream_drop_own(streams.outgoing);
 }
@@ -81,7 +76,6 @@ void drop_udp_socket(udp_socket_t socket) {
     default: /* unreachable */ abort();
     }
 
-    poll_pollable_drop_own(socket.socket_pollable);
     udp_udp_socket_drop_own(socket.socket);
 }
 
@@ -122,10 +116,6 @@ int close(int fd) {
             drop_directory_stream(entry.directory_stream_info.directory_stream);
             break;
         case DESCRIPTOR_TABLE_ENTRY_FILE_STREAM:
-            if (entry.stream.read_pollable_is_initialized)
-                poll_pollable_drop_own(entry.stream.read_pollable);
-            if (entry.stream.write_pollable_is_initialized)
-                poll_pollable_drop_own(entry.stream.write_pollable);
             if (entry.stream.file_info.readable)
                 streams_input_stream_drop_borrow(entry.stream.read_stream);
             if (entry.stream.file_info.writable)

--- a/libc-bottom-half/sources/accept-wasip2.c
+++ b/libc-bottom-half/sources/accept-wasip2.c
@@ -34,39 +34,20 @@ int tcp_accept(tcp_socket_t *socket, bool client_blocking,
 	network_error_code_t error;
 	while (!tcp_method_tcp_socket_accept(socket_borrow, &client_and_io,
 					     &error)) {
-		if (error == NETWORK_ERROR_CODE_WOULD_BLOCK) {
-			if (socket->blocking) {
-				poll_borrow_pollable_t pollable_borrow =
-					poll_borrow_pollable(
-						socket->socket_pollable);
-				poll_method_pollable_block(pollable_borrow);
-			} else {
-				errno = EWOULDBLOCK;
-				return -1;
-			}
-		} else {
-			errno = __wasi_sockets_utils__map_error(error);
-			return -1;
-		}
+                if (tcp_socket_handle_error(socket, error) < 0)
+                        return -1;
 	}
 
 	tcp_own_tcp_socket_t client = client_and_io.f0;
 	tcp_borrow_tcp_socket_t client_borrow = tcp_borrow_tcp_socket(client);
 
-	poll_own_pollable_t client_pollable =
-		tcp_method_tcp_socket_subscribe(client_borrow);
-
 	streams_own_input_stream_t input = client_and_io.f1;
 	streams_borrow_input_stream_t input_borrow =
 		streams_borrow_input_stream(input);
-	poll_own_pollable_t input_pollable =
-		streams_method_input_stream_subscribe(input_borrow);
 
 	streams_own_output_stream_t output = client_and_io.f2;
 	streams_borrow_output_stream_t output_borrow =
 		streams_borrow_output_stream(output);
-	poll_own_pollable_t output_pollable =
-		streams_method_output_stream_subscribe(output_borrow);
 
 	if (output_addr.tag != OUTPUT_SOCKADDR_NULL) {
 		network_ip_socket_address_t remote_address;
@@ -82,15 +63,12 @@ int tcp_accept(tcp_socket_t *socket, bool client_blocking,
 
 	descriptor_table_entry_t client_entry = { .tag = DESCRIPTOR_TABLE_ENTRY_TCP_SOCKET, .tcp_socket = {
         .socket = client,
-        .socket_pollable = client_pollable,
         .blocking = client_blocking,
         .fake_nodelay = socket->fake_nodelay,
         .family = socket->family,
         .state = { .tag = TCP_SOCKET_STATE_CONNECTED, .connected = {
             .input = input,
-            .input_pollable = input_pollable,
             .output = output,
-            .output_pollable = output_pollable,
         } },
         .send_timeout = 0, // Use 0 to represent no timeout
         .recv_timeout = 0,

--- a/libc-bottom-half/sources/listen.c
+++ b/libc-bottom-half/sources/listen.c
@@ -61,14 +61,8 @@ int tcp_listen(tcp_socket_t *socket, int backlog)
 
 	// Listen has successfully started. Attempt to finish it:
 	while (!tcp_method_tcp_socket_finish_listen(socket_borrow, &error)) {
-		if (error == NETWORK_ERROR_CODE_WOULD_BLOCK) {
-			poll_borrow_pollable_t pollable_borrow =
-				poll_borrow_pollable(socket->socket_pollable);
-			poll_method_pollable_block(pollable_borrow);
-		} else {
-			errno = __wasi_sockets_utils__map_error(error);
-			return -1;
-		}
+                if (tcp_socket_handle_error(socket, error) < 0)
+                        return -1;
 	}
 
 	// Listen successful.

--- a/libc-bottom-half/sources/poll-wasip2.c
+++ b/libc-bottom-half/sources/poll-wasip2.c
@@ -1,6 +1,6 @@
+#include <assert.h>
 #include <errno.h>
 #include <poll.h>
-
 #include <wasi/descriptor_table.h>
 
 typedef struct {
@@ -9,6 +9,171 @@ typedef struct {
         descriptor_table_entry_t *entry;
         short events;
 } state_t;
+
+static void add_revents(struct pollfd *pollfd, short revents, int *event_count) {
+  if (pollfd->revents == 0) {
+    *event_count += 1;
+  }
+  pollfd->revents |= revents;
+}
+
+static void add_state(state_t *states,
+                      size_t *state_index,
+                      struct pollfd *pollfd,
+                      descriptor_table_entry_t *entry,
+                      poll_own_pollable_t pollable,
+                      short events)
+{
+  states[*state_index] = (state_t){
+    .pollable = pollable,
+    .pollfd = pollfd,
+    .entry = entry,
+    .events = events
+  };
+  *state_index += 1;
+}
+
+/**
+ * Adds `pollfd` to the `states` list, incrementing `state_index` for each
+ * pollable added.
+ *
+ * This will determine, based on `pollfd`, which pollables get added to the list
+ * of pollables that are checked.
+ *
+ * Returns -1 on error and sets `errno`.
+ */
+static int add_pollfd(state_t *states,
+                      size_t *state_index,
+                      struct pollfd *pollfd,
+                      int *event_count)
+{
+    if (pollfd->fd < 0)
+        return 0;
+    descriptor_table_entry_t *entry;
+    if (!descriptor_table_get_ref(pollfd->fd, &entry)) {
+        errno = EBADF;
+        return -1;
+    }
+
+    switch (entry->tag) {
+    case DESCRIPTOR_TABLE_ENTRY_TCP_SOCKET: {
+            tcp_socket_t *socket = &(entry->tcp_socket);
+            switch (socket->state.tag) {
+            case TCP_SOCKET_STATE_CONNECTING:
+            case TCP_SOCKET_STATE_LISTENING: {
+                    if ((pollfd->events & (POLLRDNORM | POLLWRNORM)) != 0) {
+                            tcp_borrow_tcp_socket_t borrow = tcp_borrow_tcp_socket(socket->socket);
+                            add_state(states, state_index, pollfd, entry,
+                                      tcp_method_tcp_socket_subscribe(borrow),
+                                      pollfd->events);
+                    }
+                    break;
+            }
+
+            case TCP_SOCKET_STATE_CONNECTED: {
+                    if ((pollfd->events & POLLRDNORM) != 0) {
+                            streams_borrow_input_stream_t borrow =
+                                streams_borrow_input_stream(socket->state.connected.input);
+                            add_state(states, state_index, pollfd, entry,
+                                      streams_method_input_stream_subscribe(borrow),
+                                      POLLRDNORM);
+                    }
+                    if ((pollfd->events & POLLWRNORM) != 0) {
+                            streams_borrow_output_stream_t borrow =
+                                streams_borrow_output_stream(socket->state.connected.output);
+                            add_state(states, state_index, pollfd, entry,
+                                      streams_method_output_stream_subscribe(borrow),
+                                      POLLWRNORM);
+                    }
+                    break;
+            }
+
+            case TCP_SOCKET_STATE_CONNECT_FAILED: {
+                    add_revents(pollfd, pollfd->events, event_count);
+                    break;
+            }
+
+            default:
+                    errno = ENOTSUP;
+                    return -1;
+            }
+            break;
+    }
+
+    case DESCRIPTOR_TABLE_ENTRY_UDP_SOCKET: {
+            udp_socket_t *socket = &(entry->udp_socket);
+            switch (socket->state.tag) {
+            case UDP_SOCKET_STATE_UNBOUND:
+            case UDP_SOCKET_STATE_BOUND_NOSTREAMS: {
+                    add_revents(pollfd, pollfd->events, event_count);
+                    break;
+            }
+
+            case UDP_SOCKET_STATE_BOUND_STREAMING:
+            case UDP_SOCKET_STATE_CONNECTED: {
+                    udp_socket_streams_t *streams;
+                    if (socket->state.tag == UDP_SOCKET_STATE_BOUND_STREAMING) {
+                            streams = &socket->state.bound_streaming.streams;
+                    } else {
+                            streams = &socket->state.connected.streams;
+                    }
+                    if ((pollfd->events & POLLRDNORM) != 0) {
+                            udp_borrow_incoming_datagram_stream_t borrow =
+                                udp_borrow_incoming_datagram_stream(streams->incoming);
+                            add_state(states, state_index, pollfd, entry,
+                                      udp_method_incoming_datagram_stream_subscribe(borrow),
+                                      POLLRDNORM);
+                    }
+                    if ((pollfd->events & POLLWRNORM) != 0) {
+                            udp_borrow_outgoing_datagram_stream_t borrow =
+                                udp_borrow_outgoing_datagram_stream(streams->outgoing);
+                            add_state(states, state_index, pollfd, entry,
+                                      udp_method_outgoing_datagram_stream_subscribe(borrow),
+                                      POLLWRNORM);
+                    }
+                    break;
+            }
+
+            default:
+                    errno = ENOTSUP;
+                    return -1;
+            }
+            break;
+    }
+    case DESCRIPTOR_TABLE_ENTRY_FILE_STREAM: {
+        file_stream_t *stream = &entry->stream;
+        if ((pollfd->events & POLLRDNORM) != 0) {
+            if (!stream->file_info.readable) {
+                errno = EBADF;
+                return -1;
+            }
+            add_state(states, state_index, pollfd, entry,
+                      streams_method_input_stream_subscribe(stream->read_stream),
+                      POLLRDNORM);
+        }
+        if ((pollfd->events & POLLWRNORM) != 0) {
+            if (!stream->file_info.writable) {
+                errno = EBADF;
+                return -1;
+            }
+            add_state(states, state_index, pollfd, entry,
+                      streams_method_output_stream_subscribe(stream->write_stream),
+                      POLLWRNORM);
+        }
+        break;
+    }
+    // File must be open
+    case DESCRIPTOR_TABLE_ENTRY_FILE_HANDLE:
+            errno = EBADF;
+            return -1;
+    default:
+            errno = ENOTSUP;
+            return -1;
+    }
+
+
+    return 0;
+}
 
 int poll_wasip2(struct pollfd *fds, size_t nfds, int timeout)
 {
@@ -19,186 +184,20 @@ int poll_wasip2(struct pollfd *fds, size_t nfds, int timeout)
 
         size_t max_pollables = (2 * nfds) + 1;
         state_t states[max_pollables];
+        poll_borrow_pollable_t pollables[max_pollables];
         size_t state_index = 0;
         for (size_t i = 0; i < nfds; ++i) {
-                struct pollfd *pollfd = fds + i;
-                descriptor_table_entry_t *entry;
-                if (pollfd->fd < 0)
-                    continue;
-                if (descriptor_table_get_ref(pollfd->fd, &entry)) {
-                        switch (entry->tag) {
-                        case DESCRIPTOR_TABLE_ENTRY_TCP_SOCKET: {
-                                tcp_socket_t *socket = &(entry->tcp_socket);
-                                switch (socket->state.tag) {
-                                case TCP_SOCKET_STATE_CONNECTING:
-                                case TCP_SOCKET_STATE_LISTENING: {
-                                        if ((pollfd->events &
-                                             (POLLRDNORM | POLLWRNORM)) != 0) {
-                                                states[state_index++] = (state_t){
-                                                        .pollable =
-                                                                socket->socket_pollable,
-                                                        .pollfd = pollfd,
-                                                        .entry = entry,
-                                                        .events = pollfd->events
-                                                };
-                                        }
-                                        break;
-                                }
-
-                                case TCP_SOCKET_STATE_CONNECTED: {
-                                        if ((pollfd->events & POLLRDNORM) !=
-                                            0) {
-                                                states[state_index++] = (state_t){
-                                                        .pollable =
-                                                                socket->state
-                                                                        .connected
-                                                                        .input_pollable,
-                                                        .pollfd = pollfd,
-                                                        .entry = entry,
-                                                        .events = POLLRDNORM
-                                                };
-                                        }
-                                        if ((pollfd->events & POLLWRNORM) !=
-                                            0) {
-                                                states[state_index++] = (state_t){
-                                                        .pollable =
-                                                                socket->state
-                                                                        .connected
-                                                                        .output_pollable,
-                                                        .pollfd = pollfd,
-                                                        .entry = entry,
-                                                        .events = POLLWRNORM
-                                                };
-                                        }
-                                        break;
-                                }
-
-                                case TCP_SOCKET_STATE_CONNECT_FAILED: {
-                                        if (pollfd->revents == 0) {
-                                                ++event_count;
-                                        }
-                                        pollfd->revents |= pollfd->events;
-                                        break;
-                                }
-
-                                default:
-                                        errno = ENOTSUP;
-                                        return -1;
-                                }
-                                break;
-                        }
-
-                        case DESCRIPTOR_TABLE_ENTRY_UDP_SOCKET: {
-                                udp_socket_t *socket = &(entry->udp_socket);
-                                switch (socket->state.tag) {
-                                case UDP_SOCKET_STATE_UNBOUND:
-                                case UDP_SOCKET_STATE_BOUND_NOSTREAMS: {
-                                        if (pollfd->revents == 0) {
-                                                ++event_count;
-                                        }
-                                        pollfd->revents |= pollfd->events;
-                                        break;
-                                }
-
-                                case UDP_SOCKET_STATE_BOUND_STREAMING:
-                                case UDP_SOCKET_STATE_CONNECTED: {
-                                        udp_socket_streams_t *streams;
-                                        if (socket->state.tag ==
-                                            UDP_SOCKET_STATE_BOUND_STREAMING) {
-                                                streams = &(
-                                                        socket->state
-                                                                .bound_streaming
-                                                                .streams);
-                                        } else {
-                                                streams = &(
-                                                        socket->state.connected
-                                                                .streams);
-                                        }
-                                        if ((pollfd->events & POLLRDNORM) !=
-                                            0) {
-                                                states[state_index++] = (state_t){
-                                                        .pollable =
-                                                                streams->incoming_pollable,
-                                                        .pollfd = pollfd,
-                                                        .entry = entry,
-                                                        .events = POLLRDNORM
-                                                };
-                                        }
-                                        if ((pollfd->events & POLLWRNORM) !=
-                                            0) {
-                                                states[state_index++] = (state_t){
-                                                        .pollable =
-                                                                streams->outgoing_pollable,
-                                                        .pollfd = pollfd,
-                                                        .entry = entry,
-                                                        .events = POLLWRNORM
-                                                };
-                                        }
-                                        break;
-                                }
-
-                                default:
-                                        errno = ENOTSUP;
-                                        return -1;
-                                }
-                                break;
-                        }
-                        case DESCRIPTOR_TABLE_ENTRY_FILE_STREAM: {
-                            file_stream_t *stream = &entry->stream;
-                            if ((pollfd->events & POLLRDNORM) != 0) {
-                                if (!stream->file_info.readable) {
-                                    errno = EBADF;
-                                    return -1;
-                                }
-                                streams_own_pollable_t input_stream_pollable = stream->read_pollable;
-                                if (!stream->read_pollable_is_initialized) {
-                                    input_stream_pollable = stream->read_pollable = streams_method_input_stream_subscribe(stream->read_stream);
-                                    stream->read_pollable_is_initialized = true;
-                                }
-                                states[state_index++] = (state_t) {
-                                    .pollable = input_stream_pollable,
-                                    .pollfd = pollfd,
-                                    .entry = entry,
-                                    .events = pollfd->events
-                                };
-                            }
-                            if ((pollfd->events & POLLWRNORM) != 0) {
-                                if (!stream->file_info.writable) {
-                                    errno = EBADF;
-                                    return -1;
-                                }
-                                streams_own_pollable_t output_stream_pollable = stream->write_pollable;
-                                if (!stream->write_pollable_is_initialized) {
-                                    output_stream_pollable = stream->write_pollable = streams_method_output_stream_subscribe(stream->write_stream);
-                                    stream->write_pollable_is_initialized = true;
-                                }
-                                states[state_index++] = (state_t){
-                                    .pollable = output_stream_pollable,
-                                    .pollfd = pollfd,
-                                    .entry = entry,
-                                    .events = pollfd->events
-                                };
-                            }
-                            break;
-                        }
-                        // File must be open
-                        case DESCRIPTOR_TABLE_ENTRY_FILE_HANDLE:
-                                errno = EBADF;
-                                return -1;
-                        default:
-                                errno = ENOTSUP;
-                                return -1;
-                        }
-                } else {
-                        abort();
+                if (add_pollfd(states, &state_index, fds + i, &event_count) < 0) {
+                    event_count = -1;
+                    goto cleanup_states;
                 }
         }
 
         if (event_count > 0 && timeout != 0) {
-                return event_count;
+                goto cleanup_states;
         }
+        assert(state_index < max_pollables);
 
-        poll_borrow_pollable_t pollables[state_index + 1];
         for (size_t i = 0; i < state_index; ++i) {
                 pollables[i] = poll_borrow_pollable(states[i].pollable);
         }
@@ -208,92 +207,53 @@ int poll_wasip2(struct pollfd *fds, size_t nfds, int timeout)
         if (timeout >= 0) {
                 timeout_pollable = monotonic_clock_subscribe_duration(
                         ((monotonic_clock_duration_t)timeout) * 1000000);
-                pollables[pollable_count++] =
-                        poll_borrow_pollable(timeout_pollable);
+                pollables[pollable_count++] = poll_borrow_pollable(timeout_pollable);
         }
 
         wasip2_list_u32_t ready;
         poll_list_borrow_pollable_t list = {
-                .ptr = (poll_borrow_pollable_t *)&pollables,
+                .ptr = pollables,
                 .len = pollable_count
         };
         poll_poll(&list, &ready);
 
         for (size_t i = 0; i < ready.len; ++i) {
                 size_t index = ready.ptr[i];
-                if (index < state_index) {
-                        state_t *state = &states[index];
-                        if (state->entry->tag ==
-                                    DESCRIPTOR_TABLE_ENTRY_TCP_SOCKET &&
-                            state->entry->tcp_socket.state.tag ==
-                                    TCP_SOCKET_STATE_CONNECTING) {
-                                tcp_socket_t *socket =
-                                        &(state->entry->tcp_socket);
-                                tcp_borrow_tcp_socket_t borrow =
-                                        tcp_borrow_tcp_socket(socket->socket);
-                                tcp_tuple2_own_input_stream_own_output_stream_t
-                                        tuple;
-                                tcp_error_code_t error;
-                                if (tcp_method_tcp_socket_finish_connect(
-                                            borrow, &tuple, &error)) {
-                                        streams_borrow_input_stream_t
-                                                input_stream_borrow =
-                                                        streams_borrow_input_stream(
-                                                                tuple.f0);
-                                        streams_own_pollable_t input_pollable =
-                                                streams_method_input_stream_subscribe(
-                                                        input_stream_borrow);
-                                        streams_borrow_output_stream_t
-                                                output_stream_borrow =
-                                                        streams_borrow_output_stream(
-                                                                tuple.f1);
-                                        streams_own_pollable_t output_pollable =
-                                                streams_method_output_stream_subscribe(
-                                                        output_stream_borrow);
-                                        socket->state =
-                                                (tcp_socket_state_t){ .tag = TCP_SOCKET_STATE_CONNECTED,
-                                                                      .connected = {
-                                                                              .input_pollable =
-                                                                                      input_pollable,
-                                                                              .input =
-                                                                                      tuple.f0,
-                                                                              .output_pollable =
-                                                                                      output_pollable,
-                                                                              .output =
-                                                                                      tuple.f1,
-                                                                      } };
-                                        if (state->pollfd->revents == 0) {
-                                                ++event_count;
-                                        }
-                                        state->pollfd->revents |= state->events;
-                                } else if (error ==
-                                           NETWORK_ERROR_CODE_WOULD_BLOCK) {
-                                        // No events yet -- application will need to poll again
-                                } else {
-                                        socket->state =
-                                                (tcp_socket_state_t){ .tag = TCP_SOCKET_STATE_CONNECT_FAILED,
-                                                                      .connect_failed = {
-                                                                              .error_code =
-                                                                                      error,
-                                                                      } };
-                                        if (state->pollfd->revents == 0) {
-                                                ++event_count;
-                                        }
-                                        state->pollfd->revents |= state->events;
-                                }
-                        } else if (state->entry->tag == DESCRIPTOR_TABLE_ENTRY_FILE_STREAM) {
-                                if (state->pollfd->revents == 0) {
-                                        ++event_count;
-                                }
-                                state->pollfd->revents |= state->events;
+                if (index >= state_index)
+                        continue;
+                state_t *state = &states[index];
+                if (state->entry->tag ==
+                            DESCRIPTOR_TABLE_ENTRY_TCP_SOCKET &&
+                    state->entry->tcp_socket.state.tag ==
+                            TCP_SOCKET_STATE_CONNECTING) {
+                        tcp_socket_t *socket = &state->entry->tcp_socket;
+                        tcp_borrow_tcp_socket_t borrow =
+                                tcp_borrow_tcp_socket(socket->socket);
+                        tcp_tuple2_own_input_stream_own_output_stream_t tuple;
+                        tcp_error_code_t error;
+                        if (tcp_method_tcp_socket_finish_connect(
+                                    borrow, &tuple, &error)) {
+                                socket->state = (tcp_socket_state_t){
+                                    .tag = TCP_SOCKET_STATE_CONNECTED,
+                                    .connected = {
+                                        .input = tuple.f0,
+                                        .output = tuple.f1,
+                                    }
+                                };
+                                add_revents(state->pollfd, state->events, &event_count);
+                        } else if (error == NETWORK_ERROR_CODE_WOULD_BLOCK) {
+                                // No events yet -- application will need to poll again
+                        } else {
+                                socket->state = (tcp_socket_state_t){
+                                    .tag = TCP_SOCKET_STATE_CONNECT_FAILED,
+                                    .connect_failed = { .error_code = error },
+                                };
+                                add_revents(state->pollfd, state->events, &event_count);
                         }
-                        else {
-                                if (state->pollfd->revents == 0) {
-                                        ++event_count;
-                                }
-                                state->pollfd->revents |= state->events;
-                        }
+                } else {
+                        add_revents(state->pollfd, state->events, &event_count);
                 }
+
         }
 
         wasip2_list_u32_free(&ready);
@@ -302,5 +262,9 @@ int poll_wasip2(struct pollfd *fds, size_t nfds, int timeout)
                 poll_pollable_drop_own(timeout_pollable);
         }
 
+cleanup_states:
+        for (size_t i = 0; i < state_index; ++i) {
+                poll_pollable_drop_own(states[i].pollable);
+        }
         return event_count;
 }

--- a/libc-bottom-half/sources/recv.c
+++ b/libc-bottom-half/sources/recv.c
@@ -61,24 +61,21 @@ static ssize_t tcp_recvfrom(tcp_socket_t *socket, uint8_t *buffer,
 			wasip2_list_u8_free(&result);
 			return result.len;
 		} else if (should_block) {
-                        poll_borrow_pollable_t pollable_borrow =
-                            poll_borrow_pollable(connection.input_pollable);
+                        poll_own_pollable_t pollable =
+                            streams_method_input_stream_subscribe(rx_borrow);
                         if (socket->recv_timeout != 0) {
                             monotonic_clock_own_pollable_t timeout_pollable =
                                 monotonic_clock_subscribe_duration(socket->recv_timeout);
                             poll_list_borrow_pollable_t pollables;
-                            pollables.ptr = malloc(sizeof(poll_borrow_pollable_t) * 2);
-                            if (!pollables.ptr) {
-                                errno = ENOMEM;
-                                return -1;
-                            }
-                            pollables.ptr[0] = pollable_borrow;
+                            poll_borrow_pollable_t pollables_ptr[2];
+                            pollables.ptr = pollables_ptr;
+                            pollables.ptr[0] = poll_borrow_pollable(pollable);
                             pollables.ptr[1] = poll_borrow_pollable(timeout_pollable);
                             pollables.len = 2;
                             wasip2_list_u32_t ret;
                             poll_poll(&pollables, &ret);
                             poll_pollable_drop_own(timeout_pollable);
-                            poll_list_borrow_pollable_free(&pollables);
+                            poll_pollable_drop_own(pollable);
                             for (size_t i = 0; i < ret.len; i++) {
                                 if (ret.ptr[i] == 1) {
                                     // Timed out
@@ -88,8 +85,10 @@ static ssize_t tcp_recvfrom(tcp_socket_t *socket, uint8_t *buffer,
                                 }
                             }
                             wasip2_list_u32_free(&ret);
-                        } else
-                            poll_method_pollable_block(pollable_borrow);
+                        } else {
+                            poll_method_pollable_block(poll_borrow_pollable(pollable));
+                            poll_pollable_drop_own(pollable);
+                        }
 		} else {
 			errno = EWOULDBLOCK;
 			return -1;
@@ -180,9 +179,10 @@ static ssize_t udp_recvfrom(udp_socket_t *socket, uint8_t *buffer,
 			return return_real_size ? datagram_size : bytes_to_copy;
 
 		} else if (should_block) {
-			poll_borrow_pollable_t pollable_borrow =
-				poll_borrow_pollable(streams.incoming_pollable);
-			poll_method_pollable_block(pollable_borrow);
+                        poll_own_pollable_t pollable =
+                            udp_method_incoming_datagram_stream_subscribe(incoming_borrow);
+			poll_method_pollable_block(poll_borrow_pollable(pollable));
+                        poll_pollable_drop_own(pollable);
 		} else {
 			errno = EWOULDBLOCK;
 			return -1;

--- a/libc-bottom-half/sources/send.c
+++ b/libc-bottom-half/sources/send.c
@@ -65,25 +65,21 @@ static ssize_t tcp_sendto(tcp_socket_t *socket, const uint8_t *buffer,
 				return count;
 			}
 		} else if (should_block) {
-			poll_borrow_pollable_t pollable_borrow =
-				poll_borrow_pollable(
-					connection.output_pollable);
+                        poll_own_pollable_t pollable =
+                            streams_method_output_stream_subscribe(tx_borrow);
                         if (socket->send_timeout != 0) {
                             monotonic_clock_own_pollable_t timeout_pollable =
                                 monotonic_clock_subscribe_duration(socket->send_timeout);
                             poll_list_borrow_pollable_t pollables;
-                            pollables.ptr = malloc(sizeof(poll_borrow_pollable_t) * 2);
-                            if (!pollables.ptr) {
-                                errno = ENOMEM;
-                                return -1;
-                            }
-                            pollables.ptr[0] = pollable_borrow;
+                            poll_borrow_pollable_t pollables_ptr[2];
+                            pollables.ptr = pollables_ptr;
+                            pollables.ptr[0] = poll_borrow_pollable(pollable);
                             pollables.ptr[1] = poll_borrow_pollable(timeout_pollable);
                             pollables.len = 2;
                             wasip2_list_u32_t ret;
                             poll_poll(&pollables, &ret);
                             poll_pollable_drop_own(timeout_pollable);
-                            poll_list_borrow_pollable_free(&pollables);
+                            poll_pollable_drop_own(pollable);
                             for (size_t i = 0; i < ret.len; i++) {
                                 if (ret.ptr[i] == 1) {
                                     // Timed out
@@ -93,10 +89,10 @@ static ssize_t tcp_sendto(tcp_socket_t *socket, const uint8_t *buffer,
                                 }
                             }
                             wasip2_list_u32_free(&ret);
-                        } else
-                            poll_method_pollable_block(pollable_borrow);
-
-			poll_method_pollable_block(pollable_borrow);
+                        } else {
+                            poll_method_pollable_block(poll_borrow_pollable(pollable));
+                            poll_pollable_drop_own(pollable);
+                        }
 		} else {
 			errno = EWOULDBLOCK;
 			return -1;
@@ -234,9 +230,10 @@ static ssize_t udp_sendto(udp_socket_t *socket, const uint8_t *buffer,
 		}
 
 		if (should_block) {
-			poll_borrow_pollable_t pollable_borrow =
-				poll_borrow_pollable(streams.outgoing_pollable);
-			poll_method_pollable_block(pollable_borrow);
+                        poll_own_pollable_t pollable =
+                            udp_method_outgoing_datagram_stream_subscribe(outgoing_borrow);
+			poll_method_pollable_block(poll_borrow_pollable(pollable));
+                        poll_pollable_drop_own(pollable);
 		} else {
 			errno = EWOULDBLOCK;
 			return -1;

--- a/libc-bottom-half/sources/socket.c
+++ b/libc-bottom-half/sources/socket.c
@@ -13,15 +13,10 @@ static int tcp_socket(network_ip_address_family_t family, bool blocking)
 		return -1;
 	}
 
-	tcp_borrow_tcp_socket_t socket_borrow = tcp_borrow_tcp_socket(socket);
-	poll_own_pollable_t socket_pollable =
-		tcp_method_tcp_socket_subscribe(socket_borrow);
-
 	descriptor_table_entry_t
 		entry = { .tag = DESCRIPTOR_TABLE_ENTRY_TCP_SOCKET,
 			  .tcp_socket = {
 				  .socket = socket,
-				  .socket_pollable = socket_pollable,
 				  .blocking = blocking,
 				  .fake_nodelay = false,
 				  .family = family,
@@ -49,15 +44,10 @@ static int udp_socket(network_ip_address_family_t family, bool blocking)
 		return -1;
 	}
 
-	udp_borrow_udp_socket_t socket_borrow = udp_borrow_udp_socket(socket);
-	poll_own_pollable_t socket_pollable =
-		udp_method_udp_socket_subscribe(socket_borrow);
-
 	descriptor_table_entry_t
 		entry = { .tag = DESCRIPTOR_TABLE_ENTRY_UDP_SOCKET,
 			  .udp_socket = {
 				  .socket = socket,
-				  .socket_pollable = socket_pollable,
 				  .blocking = blocking,
 				  .family = family,
 				  .state = { .tag = UDP_SOCKET_STATE_UNBOUND,


### PR DESCRIPTION
This reduces the amount of state that needs to be managed in the table and also mirrors the adapter where it creates pollables on-the-fly. In general pollables are intended to be cheap to create so it should be ok to avoid caching them and carefully managing where they're located.

This commit additionally refactors the implementation of `poll` to be split into separate functions rather than all one large function.