### PR TITLE
Don't include wasip2.h in public headers

### DIFF
--- a/libc-bottom-half/headers/public/__header_time.h
+++ b/libc-bottom-half/headers/public/__header_time.h
@@ -10,9 +10,7 @@
 #include <__struct_tm.h>
 #include <__typedef_clockid_t.h>
 
-#ifdef __wasilibc_use_wasip2
-#include <wasi/wasip2.h>
-#else
+#ifndef __wasilibc_use_wasip2
 #include <wasi/api.h>
 #endif
 


### PR DESCRIPTION
Defines too many symbols for downstream consumers (fails Python's build)