### PR TITLE
wasip2: Fix implementation of `usleep`

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/unistd/usleep.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/usleep.c
@@ -9,7 +9,12 @@
 int usleep(useconds_t useconds) {
   struct timespec ts = {.tv_sec = useconds / 1000000,
                         .tv_nsec = useconds % 1000000 * 1000};
-  int error = clock_nanosleep(CLOCK_REALTIME, 0, &ts, NULL);
+#ifdef __wasilibc_use_wasip2
+  clockid_t clock_id = CLOCK_MONOTONIC;
+#else
+  clockid_t clock_id = CLOCK_REALTIME;
+#endif
+  int error = clock_nanosleep(clock_id, 0, &ts, NULL);
   if (error != 0) {
     errno = error;
     return -1;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -306,6 +306,7 @@ add_wasilibc_test(time.c)
 add_wasilibc_test(utime.c FS)
 add_wasilibc_test(rewinddir.c FS)
 add_wasilibc_test(seekdir.c FS)
+add_wasilibc_test(usleep.c)
 
 if (TARGET_TRIPLE MATCHES "-threads")
   add_wasilibc_test(busywait.c)

--- a/test/src/usleep.c
+++ b/test/src/usleep.c
@@ -1,0 +1,38 @@
+#include <sys/time.h>
+#include <time.h>
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "test.h"
+
+#define TEST(c) do { \
+	errno = 0; \
+	if (!(c)) \
+		t_error("%s failed (errno = %d)\n", #c, errno); \
+} while(0)
+
+int main(void)
+{
+    // Sleep for a total of 5ms
+    long ns_to_sleep = 5E6;
+
+    struct timespec start_time, end_time;
+    clock_gettime(CLOCK_MONOTONIC, &start_time);
+    TEST(usleep(ns_to_sleep / 1000) == 0);
+    clock_gettime(CLOCK_MONOTONIC, &end_time);
+    TEST(end_time.tv_sec - start_time.tv_sec <= 1);
+
+    long nanoseconds_elapsed = (end_time.tv_sec - start_time.tv_sec) * 1E9
+        - start_time.tv_nsec
+        + end_time.tv_nsec;
+
+    // Test that the difference between the requested amount of sleep
+    // and the actual elapsed time is within an acceptable margin
+    double difference = abs(nanoseconds_elapsed - ns_to_sleep)
+                        / ns_to_sleep;
+
+    // Allow the actual sleep time to be twice as much as the requested time
+    TEST(difference >= 0 && difference <= 1);
+
+    return t_status;
+}


### PR DESCRIPTION
Currently `CLOCK_REALTIME` is rejected in `clock_nanosleep`, so use `CLOCK_MONOTONIC` instead.