### PR TITLE
wasip2: Fix utimensat implementation

### DIFF
--- a/test/src/utime.c
+++ b/test/src/utime.c
@@ -9,6 +9,7 @@
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
+#include <sys/time.h>
 #include "test.h"
 
 #define TEST(c, ...) ((c) ? 1 : (t_error(#c" failed: " __VA_ARGS__),0))
@@ -24,27 +25,32 @@ static FILE *make_temp_file() {
     return f;
 }
 
-int main(void)
+static int doit_futimens(int fd, const struct timespec times[2]) {
+    return futimens(fd, times);
+}
+
+static int doit_utimensat(int fd, const struct timespec times[2]) {
+    return utimensat(AT_FDCWD, "temp_file", times, 0);
+}
+
+void run(int (*set_times)(int, const struct timespec[2]))
 {
 	struct stat st;
 	FILE *f;
 	int fd;
 	time_t t;
 
-	TEST(futimens(-1, ((struct timespec[2]){{.tv_nsec=UTIME_OMIT},{.tv_nsec=UTIME_OMIT}}))==0 || errno==EBADF,
-		"%s\n", strerror(errno));
-
-	if (!TEST(f = make_temp_file())) return t_status;
+	if (!TEST(f = make_temp_file())) return;
 	fd = fileno(f);
 
-	TEST(futimens(fd, (struct timespec[2]){0}) == 0, "\n");
+	TEST(set_times(fd, (struct timespec[2]){0}) == 0, "\n");
 	TEST(fstat(fd, &st) == 0, "\n");
 	TESTVAL(st.st_atim.tv_sec,==,0);
 	TESTVAL(st.st_atim.tv_nsec,==,0);
 	TESTVAL(st.st_mtim.tv_sec,==,0);
 	TESTVAL(st.st_mtim.tv_nsec,==,0);
 
-	TEST(futimens(fd, ((struct timespec[2]){{.tv_sec=1,.tv_nsec=UTIME_OMIT},{.tv_sec=1,.tv_nsec=UTIME_OMIT}})) == 0, "\n");
+	TEST(set_times(fd, ((struct timespec[2]){{.tv_sec=1,.tv_nsec=UTIME_OMIT},{.tv_sec=1,.tv_nsec=UTIME_OMIT}})) == 0, "\n");
 	TEST(fstat(fd, &st) == 0, "\n");
 	TESTVAL(st.st_atim.tv_sec,==,0);
 	TESTVAL(st.st_atim.tv_nsec,==,0);
@@ -53,25 +59,25 @@ int main(void)
 
 	t = time(0);
 
-	TEST(futimens(fd, ((struct timespec[2]){{.tv_nsec=UTIME_NOW},{.tv_nsec=UTIME_OMIT}})) == 0, "\n");
+	TEST(set_times(fd, ((struct timespec[2]){{.tv_nsec=UTIME_NOW},{.tv_nsec=UTIME_OMIT}})) == 0, "\n");
 	TEST(fstat(fd, &st) == 0, "\n");
 	TESTVAL(st.st_atim.tv_sec,>=,t);
 	TESTVAL(st.st_mtim.tv_sec,==,0);
 	TESTVAL(st.st_mtim.tv_nsec,==,0);
 
-	TEST(futimens(fd, (struct timespec[2]){0}) == 0, "\n");
-	TEST(futimens(fd, ((struct timespec[2]){{.tv_nsec=UTIME_OMIT},{.tv_nsec=UTIME_NOW}})) == 0, "\n");
+	TEST(set_times(fd, (struct timespec[2]){0}) == 0, "\n");
+	TEST(set_times(fd, ((struct timespec[2]){{.tv_nsec=UTIME_OMIT},{.tv_nsec=UTIME_NOW}})) == 0, "\n");
 	TEST(fstat(fd, &st) == 0, "\n");
 	TESTVAL(st.st_atim.tv_sec,==,0);
 	TESTVAL(st.st_mtim.tv_sec,>=,t);
 
-	TEST(futimens(fd, ((struct timespec[2]){{.tv_nsec=UTIME_NOW},{.tv_nsec=UTIME_OMIT}})) == 0, "\n");
+	TEST(set_times(fd, ((struct timespec[2]){{.tv_nsec=UTIME_NOW},{.tv_nsec=UTIME_OMIT}})) == 0, "\n");
 	TEST(fstat(fd, &st) == 0, "\n");
 	TESTVAL(st.st_atim.tv_sec,>=,t);
 	TESTVAL(st.st_mtim.tv_sec,>=,t);
 
 	if (TEST((time_t)(1LL<<32) == (1LL<<32), "implementation has Y2038 EOL\n")) {
-		if (TEST(futimens(fd, ((struct timespec[2]){{.tv_sec=1LL<<32},{.tv_sec=1LL<<32}})) == 0, "%s\n", strerror(errno))) {
+		if (TEST(set_times(fd, ((struct timespec[2]){{.tv_sec=1LL<<32},{.tv_sec=1LL<<32}})) == 0, "%s\n", strerror(errno))) {
 			TEST(fstat(fd, &st) == 0, "\n");
 			TESTVAL(st.st_atim.tv_sec, ==, 1LL<<32);
 			TESTVAL(st.st_mtim.tv_sec, ==, 1LL<<32);
@@ -79,6 +85,16 @@ int main(void)
 	}
 
 	fclose(f);
+}
+
+int main(void)
+{
+	TEST(futimens(-1, ((struct timespec[2]){{.tv_nsec=UTIME_OMIT},{.tv_nsec=UTIME_OMIT}}))==0 || errno==EBADF,
+		"%s\n", strerror(errno));
+        fprintf(stderr, "testing futimens...\n");
+        run(doit_futimens);
+        fprintf(stderr, "testing utimensat...\n");
+        run(doit_utimensat);
 
 	return t_status;
 }


### PR DESCRIPTION
Don't use a WASIp1-centric helper, instead make it WASIp2-specific. Then use the same helper that futimens is using to ensure that both have the same behavior.