### PR TITLE
wasip2: Fix `clock_nanosleep` with `TIMER_ABSTIME`

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/time/clock_nanosleep.c
+++ b/libc-bottom-half/cloudlibc/src/libc/time/clock_nanosleep.c
@@ -32,7 +32,12 @@ int clock_nanosleep(clockid_t clock_id, int flags, const struct timespec *rqtp,
 
   // Prepare pollable
   int64_t duration = (rqtp->tv_sec * NSEC_PER_SEC) + rqtp->tv_nsec;
-  monotonic_clock_own_pollable_t pollable = monotonic_clock_subscribe_duration(duration);
+  monotonic_clock_own_pollable_t pollable;
+  if (flags & TIMER_ABSTIME) {
+    pollable = monotonic_clock_subscribe_instant(duration);
+  } else {
+    pollable = monotonic_clock_subscribe_duration(duration);
+  }
 
   // Block until polling event is triggered.
   poll_method_pollable_block(poll_borrow_pollable(pollable));

--- a/test/src/clock_nanosleep.c
+++ b/test/src/clock_nanosleep.c
@@ -11,6 +11,26 @@
 		t_error("%s failed (errno = %d)\n", #c, errno); \
 } while(0)
 
+static void test_elapsed_not_too_long(
+    struct timespec *start_time,
+    struct timespec *end_time,
+    long ns_to_sleep)
+{
+    TEST(end_time->tv_sec - start_time->tv_sec <= 1);
+
+    long nanoseconds_elapsed = (end_time->tv_sec - start_time->tv_sec) * 1E9
+        - start_time->tv_nsec
+        + end_time->tv_nsec;
+
+    // Test that the difference between the requested amount of sleep
+    // and the actual elapsed time is within an acceptable margin
+    double difference = abs(nanoseconds_elapsed - ns_to_sleep)
+                        / ns_to_sleep;
+
+    // Allow the actual sleep time to be twice as much as the requested time
+    TEST(difference <= 1);
+}
+
 int main(void)
 {
     // Get the clock resolution
@@ -25,23 +45,30 @@ int main(void)
     struct timespec time_to_sleep = { .tv_sec = 0, .tv_nsec = ns_to_sleep };
 
     struct timespec start_time, end_time;
-    clock_gettime(CLOCK_MONOTONIC, &start_time);
 
+    clock_gettime(CLOCK_MONOTONIC, &start_time);
     TEST(clock_nanosleep(CLOCK_MONOTONIC, 0, &time_to_sleep, NULL)==0);
     clock_gettime(CLOCK_MONOTONIC, &end_time);
-    TEST(end_time.tv_sec - start_time.tv_sec <= 1);
 
-    long nanoseconds_elapsed = (end_time.tv_sec - start_time.tv_sec) * 1E9
-        - start_time.tv_nsec
-        + end_time.tv_nsec;
+    test_elapsed_not_too_long(&start_time, &end_time, ns_to_sleep);
 
-    // Test that the difference between the requested amount of sleep
-    // and the actual elapsed time is within an acceptable margin
-    double difference = abs(nanoseconds_elapsed - ns_to_sleep)
-                        / ns_to_sleep;
+    // Sleep for another 50ms to get us pretty far from 5ms from the start of
+    // this process to increase the chance the next test fails if it's not
+    // implemented correctly.
+    time_to_sleep.tv_nsec = 50E6;
+    TEST(clock_nanosleep(CLOCK_MONOTONIC, 0, &time_to_sleep, NULL)==0);
 
-    // Allow the actual sleep time to be twice as much as the requested time
-    TEST(difference <= 1);
+    clock_gettime(CLOCK_MONOTONIC, &time_to_sleep);
+    time_to_sleep.tv_nsec += ns_to_sleep;
+    if (time_to_sleep.tv_nsec >= 1E9) {
+        time_to_sleep.tv_sec += 1;
+        time_to_sleep.tv_nsec -= 1E9;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &start_time);
+    TEST(clock_nanosleep(CLOCK_MONOTONIC, TIMER_ABSTIME, &time_to_sleep, NULL)==0);
+    clock_gettime(CLOCK_MONOTONIC, &end_time);
+
+    test_elapsed_not_too_long(&start_time, &end_time, ns_to_sleep);
 
     return t_status;
 }


### PR DESCRIPTION
The implementation needs to switch between subscribing to an instant or duration depending on this flag.