### PR TITLE
wasip2: Adjust error code on invalid utf-8

### DIFF
--- a/libc-bottom-half/sources/wasip2_file_utils.c
+++ b/libc-bottom-half/sources/wasip2_file_utils.c
@@ -74,7 +74,7 @@ static int validate_utf8(const char *ptr_signed) {
 int wasip2_string_from_c(const char *s, wasip2_string_t *out) {
   int len = validate_utf8(s);
   if (len < 0) {
-    errno = ENOENT;
+    errno = EILSEQ;
     return -1;
   }
   out->ptr = (uint8_t*) s;


### PR DESCRIPTION
Use `EILSEQ` instead of `ENOENT` to match behavior of WASIp1.