### PR TITLE
wasip2: Implement `isatty`

### DIFF
--- a/libc-bottom-half/headers/private/wasi/descriptor_table.h
+++ b/libc-bottom-half/headers/private/wasi/descriptor_table.h
@@ -57,6 +57,8 @@ typedef struct descriptor_vtable_t {
   int (*fcntl_getfl)(void*);
   /// Implementation of `fnctl(fd, F_SETFL)`.
   int (*fcntl_setfl)(void*, int);
+  /// Implementation of `isatty`-the-function.
+  int (*isatty)(void*);
 
   // =====================================================================
   // Sockets-related APIs

--- a/libc-bottom-half/sources/isatty.c
+++ b/libc-bottom-half/sources/isatty.c
@@ -11,12 +11,15 @@
 int __isatty(int fd) {
 #ifdef __wasilibc_use_wasip2
   // Translate the file descriptor into an internal handle
-  filesystem_borrow_descriptor_t file_handle;
-  if (fd_to_file_handle(fd, &file_handle) < 0)
+  descriptor_table_entry_t *entry = descriptor_table_get_ref(fd);
+  if (!entry)
     return 0;
+  if (!entry->vtable->isatty) {
+    errno = ENOTTY;
+    return 0;
+  }
 
-  errno = ENOTTY;
-  return 0;
+  return entry->vtable->isatty(entry->data);
 #else
 
     __wasi_fdstat_t statbuf;

--- a/libc-bottom-half/sources/wasip2_stdio.c
+++ b/libc-bottom-half/sources/wasip2_stdio.c
@@ -91,12 +91,45 @@ static int stdio_fcntl_getfl(void *data) {
   }
 }
 
+static int stdio_isatty(void *data) {
+  stdio_t *stdio = (stdio_t *)data;
+  switch (stdio->fd) {
+    case 0: {
+      terminal_stdin_own_terminal_input_t term_input;
+      if (!terminal_stdin_get_terminal_stdin(&term_input))
+        break;
+      terminal_input_terminal_input_drop_own(term_input);
+      return 1;
+    }
+    case 1: {
+      terminal_stdout_own_terminal_output_t term_output;
+      if (!terminal_stdout_get_terminal_stdout(&term_output))
+        break;
+      terminal_output_terminal_output_drop_own(term_output);
+      return 1;
+    }
+    case 2: {
+      terminal_stderr_own_terminal_output_t term_output;
+      if (!terminal_stderr_get_terminal_stderr(&term_output))
+        break;
+      terminal_output_terminal_output_drop_own(term_output);
+      return 1;
+    }
+    default:
+      break;
+  }
+
+  errno = ENOTTY;
+  return 0;
+}
+
 static descriptor_vtable_t stdio_vtable = {
   .free = stdio_free,
   .get_read_stream = stdio_get_read_stream,
   .get_write_stream = stdio_get_write_stream,
   .fstat = stdio_fstat,
   .fcntl_getfl = stdio_fcntl_getfl,
+  .isatty = stdio_isatty,
 };
 
 static int stdio_add(int fd) {

--- a/test/src/isatty.c
+++ b/test/src/isatty.c
@@ -28,12 +28,16 @@ int main(void)
 
         // make sure isatty can be called on stdio fds, but don't test what the
         // actual value is yet.
-        isatty(0);
+        int stdin_isatty = isatty(0);
         TEST(errno != EBADF);
-        isatty(1);
+        int stdout_isatty = isatty(1);
         TEST(errno != EBADF);
-        isatty(2);
+        int stderr_isatty = isatty(2);
         TEST(errno != EBADF);
+
+        printf("stdin isatty: %d\n", stdin_isatty);
+        printf("stdout isatty: %d\n", stdout_isatty);
+        printf("stderr isatty: %d\n", stderr_isatty);
 
 	return t_status;
 }


### PR DESCRIPTION
This commit fills out the implementation of `isatty` for WASIp2 by calling the various `wasi:*/terminal-*` functions. The presence of a terminal indicates that it's a TTY, and otherwise it's a normal fd but not a tty.