### PR TITLE
wasip2: Close handles in `stream-error`

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/unistd/read.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/read.c
@@ -32,15 +32,8 @@ ssize_t read(int fildes, void *buf, size_t nbyte) {
                                                  nbyte,
                                                  &contents,
                                                  &stream_error);
-
-  if (!ok) {
-    if (stream_error.tag == STREAMS_STREAM_ERROR_CLOSED)
-      return 0;
-    else {
-      errno = EIO;
-      return -1;
-    }
-  }
+  if (!ok)
+    return wasip2_handle_read_error(stream_error);
 
   // Copy the bytes allocated in the canonical ABI to `buf`
   memcpy(buf, contents.ptr, contents.len);

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/write.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/write.c
@@ -34,10 +34,8 @@ ssize_t write(int fildes, const void *buf, size_t nbyte) {
     ok = streams_method_output_stream_check_write(output_stream,
                                                   &num_bytes_permitted,
                                                   &stream_error);
-    if (!ok) {
-      errno = EIO;
-      return -1;
-    }
+    if (!ok)
+      return wasip2_handle_write_error(stream_error);
 
     if (num_bytes_permitted == 0)
       poll_method_pollable_block(pollable);
@@ -52,17 +50,14 @@ ssize_t write(int fildes, const void *buf, size_t nbyte) {
   ok = streams_method_output_stream_write(output_stream,
                                           &contents,
                                           &stream_error);
-  if (!ok) {
-    errno = EIO;
-    return -1;
-  }
+  if (!ok)
+    return wasip2_handle_write_error(stream_error);
 
   ok = streams_method_output_stream_blocking_flush(output_stream,
                                                    &stream_error);
-  if (!ok) {
-    errno = EIO;
-    return -1;
-  }
+  if (!ok)
+    return wasip2_handle_write_error(stream_error);
+
 
   if (off)
     *off += contents.len;


### PR DESCRIPTION
If a stream-related operation fails and it's not "closed" then there's an `own` resource within the error. Previously this leaked in wasi-libc but now it's deallocated on-the-spot. Error handling is also deduplicated across a few locations.