### PR TITLE
Fix `nanosleep` on WASIp2

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/time/nanosleep.c
+++ b/libc-bottom-half/cloudlibc/src/libc/time/nanosleep.c
@@ -6,7 +6,14 @@
 #include <time.h>
 
 int nanosleep(const struct timespec *rqtp, struct timespec *rem) {
-  int error = clock_nanosleep(CLOCK_REALTIME, 0, rqtp, rem);
+#ifdef __wasilibc_use_wasip2
+  // FIXME(WebAssembly/WASI#857): wasip2 only supports the monotonic clock for
+  // sleeping.
+  clockid_t clock = CLOCK_MONOTONIC;
+#else
+  clockid_t clock = CLOCK_REALTIME;
+#endif
+  int error = clock_nanosleep(clock, 0, rqtp, rem);
   if (error != 0) {
     errno = error;
     return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/usleep.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/usleep.c
@@ -10,6 +10,8 @@ int usleep(useconds_t useconds) {
   struct timespec ts = {.tv_sec = useconds / 1000000,
                         .tv_nsec = useconds % 1000000 * 1000};
 #ifdef __wasilibc_use_wasip2
+  // FIXME(WebAssembly/WASI#857): wasip2 only supports the monotonic clock for
+  // sleeping.
   clockid_t clock_id = CLOCK_MONOTONIC;
 #else
   clockid_t clock_id = CLOCK_REALTIME;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -281,6 +281,7 @@ add_wasilibc_test(utime.c FS)
 add_wasilibc_test(rewinddir.c FS)
 add_wasilibc_test(seekdir.c FS)
 add_wasilibc_test(usleep.c)
+add_wasilibc_test(nanosleep.c)
 add_wasilibc_test(write.c FS)
 
 if (TARGET_TRIPLE MATCHES "-threads")

--- a/test/src/nanosleep.c
+++ b/test/src/nanosleep.c
@@ -1,0 +1,39 @@
+#include "test.h"
+#include <errno.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <sys/time.h>
+#include <time.h>
+
+#define TEST(c)                                                                \
+  do {                                                                         \
+    errno = 0;                                                                 \
+    if (!(c))                                                                  \
+      t_error("%s failed (errno = %d)\n", #c, errno);                          \
+  } while (0)
+
+int main(void) {
+  // Sleep for a total of 5ms
+  long ns_to_sleep = 5E6;
+
+  struct timespec start_time, end_time;
+  clock_gettime(CLOCK_MONOTONIC, &start_time);
+  struct timespec dur;
+  dur.tv_sec = 0;
+  dur.tv_nsec = ns_to_sleep;
+  TEST(nanosleep(&dur, NULL) == 0);
+  clock_gettime(CLOCK_MONOTONIC, &end_time);
+  TEST(end_time.tv_sec - start_time.tv_sec <= 1);
+
+  long nanoseconds_elapsed = (end_time.tv_sec - start_time.tv_sec) * 1E9 -
+                             start_time.tv_nsec + end_time.tv_nsec;
+
+  // Test that the difference between the requested amount of sleep
+  // and the actual elapsed time is within an acceptable margin
+  double difference = abs(nanoseconds_elapsed - ns_to_sleep) / ns_to_sleep;
+
+  // Allow the actual sleep time to be twice as much as the requested time
+  TEST(difference <= 1);
+
+  return t_status;
+}


### PR DESCRIPTION
Like with `usleep`, use `CLOCK_MONOTONIC` instead of `CLOCK_REALTIME` as the latter isn't supported.