### PR TITLE
Remove unnecessary headers from `scandirat.c`

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/dirent/scandirat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/dirent/scandirat.c
@@ -2,24 +2,11 @@
 //
 // SPDX-License-Identifier: BSD-2-Clause
 
-#ifdef __wasilibc_use_wasip2
-#include <wasi/wasip2.h>
-#include <wasi/file_utils.h>
-#include <common/errors.h>
-#else
-#include <wasi/api.h>
-#endif
-#include <wasi/libc.h>
-#include <wasi/libc-nocwd.h>
 #include <dirent.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
-#include <sys/stat.h>
-
-#include "dirent_impl.h"
 
 static int sel_true(const struct dirent *de) {
   return 1;


### PR DESCRIPTION
This was refactored in #642 but didn't have its headers trimmed at the time, so this trims down the headers to the bare bones.