### PR TITLE
Fix a C++-specific bug in #694

### DIFF
--- a/libc-bottom-half/headers/public/wasi/api.h
+++ b/libc-bottom-half/headers/public/wasi/api.h
@@ -2119,10 +2119,10 @@ int32_t __wasi_thread_spawn(
     void *start_arg) __attribute__((__warn_unused_result__));
 #endif
 
-#endif // __wasilibc_use_wasip2
-
 #ifdef __cplusplus
 }
 #endif
+
+#endif // __wasilibc_use_wasip2
 
 #endif


### PR DESCRIPTION
This fixes the order `#define`s showed up in for C++ introduced in #694 to fix the inclusion of this repository into wasi-sdk. I don't know of a great way to test this without building a whole C++ sysroot which seems out-of-scope, so this is something I think will best be left for "try to not break it and we'll catch it in wasi-sdk".