### PR TITLE
fix(wasip2): reactors to not export cli/run

### DIFF
--- a/expected/wasm32-wasip2/defined-symbols.txt
+++ b/expected/wasm32-wasip2/defined-symbols.txt
@@ -566,7 +566,6 @@ explicit_bzero
 expm1
 expm1f
 expm1l
-exports_wasi_cli_run_run
 fabs
 fabsf
 fabsl

--- a/libc-bottom-half/crt/crt1-command.c
+++ b/libc-bottom-half/crt/crt1-command.c
@@ -3,6 +3,7 @@
 #endif
 
 #include <wasi/api.h>
+#include <stdbool.h>
 
 extern void __wasi_init_tp(void);
 extern void __wasm_call_ctors(void);
@@ -58,3 +59,15 @@ void _start(void) {
     }
 #endif
 }
+
+
+#ifdef __wasip2__
+#include <wasi/libc-environ.h>
+
+// The wasi:cli/run export for wasip2 components. This is only linked for
+// command-style executables, not reactors.
+bool exports_wasi_cli_run_run(void) {
+    __wasilibc_initialize_environ();
+    return __main_void() == 0;
+}
+#endif

--- a/libc-bottom-half/sources/__main_void.c
+++ b/libc-bottom-half/sources/__main_void.c
@@ -108,12 +108,3 @@ __attribute__((__weak__, nodebug)) int __main_void(void) {
   return __main_argc_argv(argc, argv);
 #endif
 }
-
-#ifdef __wasip2__
-bool exports_wasi_cli_run_run(void) {
-  // TODO: this is supposed to be unnecessary, but functional/env.c fails
-  // without it
-  __wasilibc_initialize_environ();
-  return __main_void() == 0;
-}
-#endif


### PR DESCRIPTION
This change enables components to be built without a wasi:cli/run export.

- Command mode (-mexec-model=command or default): Links crt1-command.o which contains exports_wasi_cli_run_run
- Reactor mode (-mexec-model=reactor): Links crt1-reactor.o which only has _initialize

I have a bit of a chicken and egg problem after removing the run export from `defined-symbols.txt` which seems to be our only test for this. I was able to test by adding additional checks in `src/llvm-project/clang/test/Driver/wasm-toolchain.c` but this wasi-libc change needs to land first for those tests to pass.

cc @alexcrichton, there are a number of refactors in flight leading up to #700. No rush on this one, it's something that's bugged me for a while.
