### PR TITLE
Add `__wasi_sdk_{major,version}__` defines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ option(BUILD_TESTS "Whether or not to build tests" OFF)
 option(SIMD "Whether or not to build simd-enabled intrinsics into wasi-libc" OFF)
 option(BUILD_SHARED "Whether or not to build shared libraries" ON)
 option(CHECK_SYMBOLS "Whether or not to check the exported symbols of libc.a" OFF)
+set(WASI_SDK_VERSION "" CACHE STRING "Version information for wasi-sdk to embed in headers")
 
 if(TARGET_TRIPLE MATCHES "-threads$")
   set(WASI p1)

--- a/libc-bottom-half/CMakeLists.txt
+++ b/libc-bottom-half/CMakeLists.txt
@@ -6,6 +6,12 @@ add_subdirectory(signal)
 # =============================================================================
 # sysroot headers from the bottom half
 #
+if(WASI_SDK_VERSION)
+  set(__wasi_sdk_version__ ${WASI_SDK_VERSION})
+  if (WASI_SDK_VERSION MATCHES "([0-9]+)\\..*")
+    set(__wasi_sdk_major__ ${CMAKE_MATCH_1})
+  endif()
+endif()
 configure_file(headers/public/wasi/version.h.in ${SYSROOT_INC}/wasi/version.h)
 add_custom_target(sysroot-wasi-snapshot-header DEPENDS ${SYSROOT_INC}/wasi/version.h)
 add_dependencies(sysroot_inc sysroot-wasi-snapshot-header)

--- a/libc-bottom-half/headers/public/wasi/version.h.in
+++ b/libc-bottom-half/headers/public/wasi/version.h.in
@@ -11,4 +11,7 @@
 #cmakedefine __wasip2__
 #cmakedefine __wasip3__
 
+#cmakedefine __wasi_sdk_major__ @__wasi_sdk_major__@
+#cmakedefine __wasi_sdk_version__ "@__wasi_sdk_version__@"
+
 #endif /* __WASI_VERSION_H */


### PR DESCRIPTION
This commit updates the generated `wasi/version.h` file with two new `#define`s:

* `__wasi_sdk_major__` set to `29` for example for `wasi-sdk-29.0`
* `__wasi_sdk_version__` set to `"29.0"` for example for `wasi-sdk-29.0`

This'll get set when building wasi-sdk itself through `-DWASI_SDK_VERSION=...` as part of the configuration of libc itself.

cc #688