### PR TITLE
Change `pthread_create` stub's error code

### DIFF
--- a/thread-stub/pthread_create.c
+++ b/thread-stub/pthread_create.c
@@ -8,12 +8,7 @@ weak_alias(dummy_0, __release_ptc);
 
 int __pthread_create(pthread_t *restrict res, const pthread_attr_t *restrict attrp, void *(*entry)(void *), void *restrict arg)
 {
-	/*
-		"The system lacked the necessary resources to create another thread,
-		or the system-imposed limit on the total number of threads in a process
-		{PTHREAD_THREADS_MAX} would be exceeded."
-	*/
-	return EAGAIN;
+	return ENOTSUP;
 }
 
 weak_alias(__pthread_create, pthread_create);


### PR DESCRIPTION
This changes from `EAGAIN` to `ENOTSUP` since this operation can't ever succeed, it's entirely unsupported. This is in relation to rust-lang/rust#151016 where in the Rust ecosystem crates were using the "Unsupported" error kind to gracefully handle errors from spawning a thread, such a falling back to single-threaded code. By switching to `EAGAIN` it caused these graceful fallbacks to not get triggered.