### PR TITLE
Delete unused `exports_wasi_cli_run_run` symbol

### DIFF
--- a/expected/wasm32-wasip2/defined-symbols.txt
+++ b/expected/wasm32-wasip2/defined-symbols.txt
@@ -566,7 +566,6 @@ explicit_bzero
 expm1
 expm1f
 expm1l
-exports_wasi_cli_run_run
 fabs
 fabsf
 fabsl

--- a/libc-bottom-half/sources/__main_void.c
+++ b/libc-bottom-half/sources/__main_void.c
@@ -120,12 +120,3 @@ __attribute__((__weak__, nodebug)) int __main_void(void) {
 #error "Unknown WASI version"
 #endif
 }
-
-#ifdef __wasip2__
-bool exports_wasi_cli_run_run(void) {
-  // TODO: this is supposed to be unnecessary, but functional/env.c fails
-  // without it
-  __wasilibc_initialize_environ();
-  return __main_void() == 0;
-}
-#endif


### PR DESCRIPTION
Not used any more, so this can be safely deleted.