### PR TITLE
Wasip3: Implement pipe, testing will need cooperative threads though

### DIFF
--- a/expected/wasm32-wasip3/defined-symbols.txt
+++ b/expected/wasm32-wasip3/defined-symbols.txt
@@ -1005,6 +1005,7 @@ optopt
 optreset
 pathconf
 perror
+pipe
 poll
 posix_close
 posix_fadvise

--- a/libc-bottom-half/CMakeLists.txt
+++ b/libc-bottom-half/CMakeLists.txt
@@ -166,6 +166,7 @@ if (WASI STREQUAL "p3")
     sources/wasip3_block_on.c
     sources/wasip3_file.c
     sources/wasip3_file_utils.c
+    sources/wasip3_pipe.c
     sources/wasip3_stdio.c
     sources/wasip3_tcp.c
     sources/wasip3_udp.c

--- a/libc-top-half/musl/include/unistd.h
+++ b/libc-top-half/musl/include/unistd.h
@@ -19,6 +19,7 @@ extern "C" {
 #define SEEK_HOLE 4
 #else
 #include <__header_unistd.h>
+#include <wasi/version.h> // for pipe availability
 #endif
 
 #ifdef __wasilibc_unmodified_upstream /* Use the compiler's definition of NULL */
@@ -45,7 +46,7 @@ extern "C" {
 
 #include <bits/alltypes.h>
 
-#ifdef __wasilibc_unmodified_upstream /* WASI has no pipe */
+#if defined(__wasilibc_unmodified_upstream) || defined(__wasip3__) /* WASI<0.3 has no pipe */
 int pipe(int [2]);
 int pipe2(int [2], int);
 #endif

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -271,6 +271,7 @@ add_wasilibc_test(memchr.c LDFLAGS -Wl,--stack-first -Wl,--initial-memory=327680
 add_wasilibc_test(memcmp.c LDFLAGS -Wl,--stack-first -Wl,--initial-memory=327680)
 add_wasilibc_test(opendir.c FS FAILP3 ARGV /)
 add_wasilibc_test(open_relative_path.c FS FAILP3 ARGV /)
+add_wasilibc_test(pipe.c)
 add_wasilibc_test(poll.c FS FAILP3)
 add_wasilibc_test(preadvwritev.c FS FAILP3)
 add_wasilibc_test(preadwrite.c FS FAILP3)

--- a/test/src/pipe.c
+++ b/test/src/pipe.c
@@ -1,0 +1,28 @@
+#include "test.h"
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#define PATTERNSIZE 16
+static const char PATTERN[PATTERNSIZE] = {
+    'A', 'B', 'C', 'D', '0', '1', '2', '3', 'a', 'b', 'c', 'd', 0, 1, 2, 3};
+
+#define TEST(c, ...) ((c) ? 1 : (t_error(#c " failed: " __VA_ARGS__), 0))
+
+int main(void) {
+#ifdef __wasip3__ // pipe only works on wasip3 or up
+  int pipefd[2];
+  char buf[PATTERNSIZE];
+  int res;
+
+  TEST(pipe(pipefd) >= 0);
+
+  TEST(write(pipefd[1], PATTERN, PATTERNSIZE) == PATTERNSIZE);
+
+  TEST(read(pipefd[0], buf, PATTERNSIZE) == PATTERNSIZE);
+
+  TEST(close(pipefd[0]) >= 0);
+  TEST(close(pipefd[1]) >= 0);
+#endif
+  return 0;
+}


### PR DESCRIPTION
This works, if 
- you also combine it with cooperative threading
- you then don't close any of the file descriptors on either side (because there is no other process)

It was a nice dream to see this in close reach, though.