### PR TITLE
wasip2: Deduplicate stream code in read/write/TCP

### DIFF
--- a/expected/wasm32-wasip2/defined-symbols.txt
+++ b/expected/wasm32-wasip2/defined-symbols.txt
@@ -334,7 +334,7 @@ __wasilibc_poll_ready
 __wasilibc_populate_preopens
 __wasilibc_pthread_self
 __wasilibc_random
-__wasilibc_read_stream
+__wasilibc_read
 __wasilibc_rename_newat
 __wasilibc_rename_oldat
 __wasilibc_reset_preopens
@@ -348,7 +348,7 @@ __wasilibc_unspecified_addr
 __wasilibc_utimens
 __wasilibc_wasi_family_to_libc
 __wasilibc_wasi_to_sockaddr
-__wasilibc_write_stream
+__wasilibc_write
 __wasm_call_dtors
 __wcscoll_l
 __wcsftime_l

--- a/libc-bottom-half/cloudlibc/src/libc/poll/poll.c
+++ b/libc-bottom-half/cloudlibc/src/libc/poll/poll.c
@@ -217,11 +217,10 @@ static int poll_impl(struct pollfd *fds, size_t nfds, int timeout) {
     if (pollfd->events & POLLRDNORM) {
       if (entry->vtable->get_read_stream) {
         streams_borrow_input_stream_t input;
-        poll_own_pollable_t *pollable;
-        if (entry->vtable->get_read_stream(entry->data, &input, NULL,
-                                           &pollable) < 0)
+        wasip2_read_t read;
+        if (entry->vtable->get_read_stream(entry->data, &read) < 0)
           return -1;
-        if (__wasilibc_poll_add_input_stream(&state, input, pollable) < 0)
+        if (__wasilibc_poll_add_input_stream(&state, read.input, read.pollable) < 0)
           return -1;
       } else {
         errno = EOPNOTSUPP;
@@ -231,12 +230,10 @@ static int poll_impl(struct pollfd *fds, size_t nfds, int timeout) {
 
     if (pollfd->events & POLLWRNORM) {
       if (entry->vtable->get_write_stream) {
-        streams_borrow_output_stream_t output;
-        poll_own_pollable_t *pollable;
-        if (entry->vtable->get_write_stream(entry->data, &output, NULL,
-                                            &pollable) < 0)
+        wasip2_write_t write;
+        if (entry->vtable->get_write_stream(entry->data, &write) < 0)
           return -1;
-        if (__wasilibc_poll_add_output_stream(&state, output, pollable) < 0)
+        if (__wasilibc_poll_add_output_stream(&state, write.output, write.pollable) < 0)
           return -1;
       } else {
         errno = EOPNOTSUPP;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/read.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/read.c
@@ -28,41 +28,19 @@ ssize_t read(int fildes, void *buf, size_t nbyte) {
   }
   return bytes_read;
 #elif defined(__wasip2__)
-  // First, check to see if this is a socket, in which case we defer to `recvfrom`:
   descriptor_table_entry_t *entry = descriptor_table_get_ref(fildes);
   if (!entry)
     return -1;
-  if (entry->vtable->recvfrom != NULL)
+  if (entry->vtable->get_read_stream) {
+    wasip2_read_t read;
+    if (entry->vtable->get_read_stream(entry->data, &read) < 0)
+      return -1;
+    return __wasilibc_read(&read, buf, nbyte);
+  }
+  if (entry->vtable->recvfrom)
     return entry->vtable->recvfrom(entry->data, buf, nbyte, 0, NULL, NULL);
-
-  bool ok = false;
-
-  // Translate the file descriptor to an internal handle
-  streams_borrow_input_stream_t input_stream;
-  off_t *off;
-  if (__wasilibc_read_stream(fildes, &input_stream, &off, NULL) < 0)
-    return -1;
-
-  // Set up a WASI list of bytes to receive the results
-  wasip2_list_u8_t contents;
-
-  // Read the bytes
-  streams_stream_error_t stream_error;
-  ok = streams_method_input_stream_blocking_read(input_stream,
-                                                 nbyte,
-                                                 &contents,
-                                                 &stream_error);
-  if (!ok)
-    return wasip2_handle_read_error(stream_error);
-
-  // Copy the bytes allocated in the canonical ABI to `buf`
-  memcpy(buf, contents.ptr, contents.len);
-  wasip2_list_u8_free(&contents);
-
-  // Update the offset
-  if (off)
-    *off += contents.len;
-  return contents.len;
+  errno = EOPNOTSUPP;
+  return -1;
 #elif defined(__wasip3__)
   filesystem_tuple2_stream_u8_future_result_void_error_code_t *stream;
   off_t *off;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/write.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/write.c
@@ -29,58 +29,19 @@ ssize_t write(int fildes, const void *buf, size_t nbyte) {
   }
   return bytes_written;
 #elif defined(__wasip2__)
-  // First, check to see if this is a socket, in which case we defer to `sendto`:
   descriptor_table_entry_t *entry = descriptor_table_get_ref(fildes);
   if (!entry)
     return -1;
-  if (entry->vtable->sendto != NULL)
-    return entry->vtable->sendto(entry->data, buf, nbyte, 0, NULL, 0);
-
-  streams_borrow_output_stream_t output_stream;
-  poll_borrow_pollable_t pollable;
-  bool ok = false;
-  filesystem_error_code_t error_code;
-
-  // Translate the file descriptor to an internal handle
-  off_t *off;
-  if (__wasilibc_write_stream(fildes, &output_stream, &off, &pollable) < 0)
-    return -1;
-
-  // Check readiness for writing
-  uint64_t num_bytes_permitted = 0;
-  streams_stream_error_t stream_error;
-  while (num_bytes_permitted == 0) {
-    ok = streams_method_output_stream_check_write(output_stream,
-                                                  &num_bytes_permitted,
-                                                  &stream_error);
-    if (!ok)
-      return wasip2_handle_write_error(stream_error);
-
-    if (num_bytes_permitted == 0)
-      poll_method_pollable_block(pollable);
+  if (entry->vtable->get_write_stream) {
+    wasip2_write_t write;
+    if (entry->vtable->get_write_stream(entry->data, &write) < 0)
+      return -1;
+    return __wasilibc_write(&write, buf, nbyte);
   }
-
-  // Convert the buffer to a WASI list of bytes
-  wasip2_list_u8_t contents;
-  contents.len = num_bytes_permitted < nbyte ? num_bytes_permitted : nbyte;
-  contents.ptr = (uint8_t*) buf;
-
-  // Write the bytes to the stream
-  ok = streams_method_output_stream_write(output_stream,
-                                          &contents,
-                                          &stream_error);
-  if (!ok)
-    return wasip2_handle_write_error(stream_error);
-
-  ok = streams_method_output_stream_blocking_flush(output_stream,
-                                                   &stream_error);
-  if (!ok)
-    return wasip2_handle_write_error(stream_error);
-
-
-  if (off)
-    *off += contents.len;
-  return contents.len;
+  if (entry->vtable->sendto)
+    return entry->vtable->sendto(entry->data, buf, nbyte, 0, NULL, 0);
+  errno = EOPNOTSUPP;
+  return -1;
 #elif defined(__wasip3__)
   wasip3_write_t *write_end;
   off_t *off;

--- a/libc-bottom-half/headers/private/wasi/file_utils.h
+++ b/libc-bottom-half/headers/private/wasi/file_utils.h
@@ -65,18 +65,16 @@ static int fd_to_file_handle(int fd, filesystem_borrow_descriptor_t* result) {
 #endif
 
 #ifdef __wasip2__
-// Gets an `output-stream` borrow from the `fd` provided.
-int __wasilibc_write_stream(int fd,
-                            streams_borrow_output_stream_t *out,
-                            off_t **off,
-                            poll_borrow_pollable_t *pollable);
-
-// Gets an `input-stream` borrow from the `fd` provided.
-int __wasilibc_read_stream(int fd,
-                           streams_borrow_input_stream_t *out,
-                           off_t **off,
-                           poll_borrow_pollable_t *pollable);
+// Reads from `read` into `buf`/`len`
+//
+// This perform the read configured by `read`, e.g. whether it's blocking or
+// not, and places the result in the specified buffer. Used to implement
+// `read` and `recvfrom`, for example.
+ssize_t __wasilibc_read(wasip2_read_t *read, void *buf, size_t len);
+// Same as `__wasilibc_read`, but for writes.
+ssize_t __wasilibc_write(wasip2_write_t *write, const void *buf, size_t len);
 #endif
+
 #ifdef __wasip3__
 int __wasilibc_write_stream3(int fildes, wasip3_write_t **write_end, off_t **off);
 int __wasilibc_read_stream3(int fildes, filesystem_tuple2_stream_u8_future_result_void_error_code_t **stream, off_t **off);

--- a/libc-bottom-half/sources/tcp.c
+++ b/libc-bottom-half/sources/tcp.c
@@ -122,39 +122,33 @@ static void tcp_free(void *data) {
 }
 
 #ifdef __wasip2__
-static int tcp_get_read_stream(void *data,
-                               streams_borrow_input_stream_t *out_stream,
-                               off_t **out_offset,
-                               poll_own_pollable_t **out_pollable) {
+static int tcp_get_read_stream(void *data, wasip2_read_t *read) {
   tcp_socket_t *tcp = (tcp_socket_t *)data;
 
   if (tcp->state.tag != TCP_SOCKET_STATE_CONNECTED) {
     errno = ENOTCONN;
     return -1;
   }
-  *out_stream = streams_borrow_input_stream(tcp->state.connected.input);
-  if (out_offset)
-    *out_offset = NULL;
-  if (out_pollable)
-    *out_pollable = &tcp->state.connected.input_pollable;
+  read->input = streams_borrow_input_stream(tcp->state.connected.input);
+  read->offset = NULL;
+  read->pollable = &tcp->state.connected.input_pollable;
+  read->timeout = tcp->recv_timeout;
+  read->blocking = tcp->blocking;
   return 0;
 }
 
-static int tcp_get_write_stream(void *data,
-                                streams_borrow_output_stream_t *out_stream,
-                                off_t **out_offset,
-                                poll_own_pollable_t **out_pollable) {
+static int tcp_get_write_stream(void *data, wasip2_write_t *write) {
   tcp_socket_t *tcp = (tcp_socket_t *)data;
 
   if (tcp->state.tag != TCP_SOCKET_STATE_CONNECTED) {
     errno = ENOTCONN;
     return -1;
   }
-  *out_stream = streams_borrow_output_stream(tcp->state.connected.output);
-  if (out_offset)
-    *out_offset = NULL;
-  if (out_pollable)
-    *out_pollable = &tcp->state.connected.output_pollable;
+  write->output = streams_borrow_output_stream(tcp->state.connected.output);
+  write->offset = NULL;
+  write->pollable = &tcp->state.connected.output_pollable;
+  write->timeout = tcp->send_timeout;
+  write->blocking = tcp->blocking;
   return 0;
 }
 #endif // __wasip2__
@@ -544,68 +538,14 @@ static ssize_t tcp_recvfrom(void *data, void *buffer, size_t length, int flags,
     return -1;
   }
 
-  if (socket->state.tag != TCP_SOCKET_STATE_CONNECTED) {
-    errno = ENOTCONN;
+  wasip2_read_t read;
+  if (tcp_get_read_stream(data, &read) < 0)
     return -1;
-  }
-  tcp_socket_state_connected_t *connection = &socket->state.connected;
 
-  bool should_block = socket->blocking;
-  if ((flags & MSG_DONTWAIT) != 0) {
-    should_block = false;
-  }
+  if ((flags & MSG_DONTWAIT) != 0)
+    read.blocking = false;
 
-  streams_borrow_input_stream_t rx_borrow =
-      streams_borrow_input_stream(connection->input);
-  while (true) {
-    wasip2_list_u8_t result;
-    streams_stream_error_t error;
-    if (!streams_method_input_stream_read(rx_borrow, length, &result, &error))
-      // TODO wasi-sockets: wasi-sockets has no way to recover TCP stream errors
-      // yet.
-      return wasip2_handle_read_error(error);
-
-    if (result.len) {
-      memcpy(buffer, result.ptr, result.len);
-      wasip2_list_u8_free(&result);
-      return result.len;
-    }
-    if (!should_block) {
-      errno = EWOULDBLOCK;
-      return -1;
-    }
-
-    if (connection->input_pollable.__handle == 0)
-      connection->input_pollable =
-          streams_method_input_stream_subscribe(rx_borrow);
-    poll_borrow_pollable_t pollable_borrow =
-        poll_borrow_pollable(connection->input_pollable);
-
-    if (socket->recv_timeout != 0) {
-      poll_own_pollable_t timeout_pollable =
-          monotonic_clock_subscribe_duration(socket->recv_timeout);
-      poll_list_borrow_pollable_t pollables;
-      poll_borrow_pollable_t pollables_ptr[2];
-      pollables.ptr = pollables_ptr;
-      pollables.ptr[0] = pollable_borrow;
-      pollables.ptr[1] = poll_borrow_pollable(timeout_pollable);
-      pollables.len = 2;
-      wasip2_list_u32_t ret;
-      poll_poll(&pollables, &ret);
-      poll_pollable_drop_own(timeout_pollable);
-      for (size_t i = 0; i < ret.len; i++) {
-        if (ret.ptr[i] == 1) {
-          // Timed out
-          errno = EWOULDBLOCK;
-          wasip2_list_u32_free(&ret);
-          return -1;
-        }
-      }
-      wasip2_list_u32_free(&ret);
-    } else {
-      poll_method_pollable_block(pollable_borrow);
-    }
-  }
+  return __wasilibc_read(&read, buffer, length);
 }
 
 static ssize_t tcp_sendto(void *data, const void *buffer, size_t length,
@@ -623,18 +563,12 @@ static ssize_t tcp_sendto(void *data, const void *buffer, size_t length,
     return -1;
   }
 
-  tcp_socket_state_connected_t *connection;
-  if (socket->state.tag == TCP_SOCKET_STATE_CONNECTED) {
-    connection = &socket->state.connected;
-  } else {
-    errno = ENOTCONN;
+  wasip2_write_t write;
+  if (tcp_get_write_stream(data, &write) < 0)
     return -1;
-  }
 
-  bool should_block = socket->blocking;
-  if ((flags & MSG_DONTWAIT) != 0) {
-    should_block = false;
-  }
+  if ((flags & MSG_DONTWAIT) != 0)
+    write.blocking = false;
 
   if ((flags & MSG_NOSIGNAL) != 0) {
     // Ignore it. WASI has no Unix-style signals. So effectively,
@@ -642,63 +576,7 @@ static ssize_t tcp_sendto(void *data, const void *buffer, size_t length,
     // requested or not.
   }
 
-  streams_borrow_output_stream_t tx_borrow =
-      streams_borrow_output_stream(connection->output);
-  while (true) {
-    streams_stream_error_t error;
-    uint64_t count;
-    if (!streams_method_output_stream_check_write(tx_borrow, &count, &error))
-      // TODO wasi-sockets: wasi-sockets has no way to recover stream errors
-      // yet.
-      return wasip2_handle_write_error(error);
-
-    if (count) {
-      count = count < length ? count : length;
-      wasip2_list_u8_t list = {.ptr = (uint8_t *)buffer, .len = count};
-      if (!streams_method_output_stream_write(tx_borrow, &list, &error)) {
-        // TODO wasi-sockets: wasi-sockets has no way to recover TCP stream
-        // errors yet.
-        return wasip2_handle_write_error(error);
-      } else {
-        return count;
-      }
-    }
-    if (!should_block) {
-      errno = EWOULDBLOCK;
-      return -1;
-    }
-
-    if (connection->output_pollable.__handle == 0)
-      connection->output_pollable =
-          streams_method_output_stream_subscribe(tx_borrow);
-    poll_borrow_pollable_t pollable_borrow =
-        poll_borrow_pollable(connection->output_pollable);
-
-    if (socket->send_timeout != 0) {
-      monotonic_clock_own_pollable_t timeout_pollable =
-          monotonic_clock_subscribe_duration(socket->send_timeout);
-      poll_list_borrow_pollable_t pollables;
-      poll_borrow_pollable_t pollables_ptr[2];
-      pollables.ptr = pollables_ptr;
-      pollables.ptr[0] = pollable_borrow;
-      pollables.ptr[1] = poll_borrow_pollable(timeout_pollable);
-      pollables.len = 2;
-      wasip2_list_u32_t ret;
-      poll_poll(&pollables, &ret);
-      poll_pollable_drop_own(timeout_pollable);
-      for (size_t i = 0; i < ret.len; i++) {
-        if (ret.ptr[i] == 1) {
-          // Timed out
-          errno = EWOULDBLOCK;
-          wasip2_list_u32_free(&ret);
-          return -1;
-        }
-      }
-      wasip2_list_u32_free(&ret);
-    } else {
-      poll_method_pollable_block(pollable_borrow);
-    }
-  }
+  return __wasilibc_write(&write, buffer, length);
 }
 
 static int tcp_shutdown(void *data, int posix_how) {

--- a/libc-bottom-half/sources/wasip2_file.c
+++ b/libc-bottom-half/sources/wasip2_file.c
@@ -54,10 +54,7 @@ static void file_free(void *data) {
   free(file);
 }
 
-static int file_get_read_stream(void *data,
-                                streams_borrow_input_stream_t *out_stream,
-                                off_t **out_offset,
-                                poll_own_pollable_t **out_pollable) {
+static int file_get_read_stream(void *data, wasip2_read_t *read) {
   file_t *file = (file_t *)data;
   if (file->read_stream.__handle == 0) {
     filesystem_error_code_t error_code;
@@ -69,18 +66,15 @@ static int file_get_read_stream(void *data,
       return -1;
     }
   }
-  *out_stream = streams_borrow_input_stream(file->read_stream);
-  if (out_offset)
-    *out_offset = &file->offset;
-  if (out_pollable)
-    *out_pollable = &file->read_pollable;
+  read->input = streams_borrow_input_stream(file->read_stream);
+  read->offset = &file->offset;
+  read->pollable = &file->read_pollable;
+  read->timeout = 0;
+  read->blocking = true;
   return 0;
 }
 
-static int file_get_write_stream(void *data,
-                                 streams_borrow_output_stream_t *out_stream,
-                                 off_t **out_offset,
-                                 poll_own_pollable_t **out_pollable) {
+static int file_get_write_stream(void *data, wasip2_write_t *write) {
   file_t *file = (file_t *)data;
   if (file->write_stream.__handle == 0) {
     filesystem_error_code_t error_code;
@@ -100,11 +94,11 @@ static int file_get_write_stream(void *data,
       return -1;
     }
   }
-  *out_stream = streams_borrow_output_stream(file->write_stream);
-  if (out_offset)
-    *out_offset = &file->offset;
-  if (out_pollable)
-    *out_pollable = &file->write_pollable;
+  write->output = streams_borrow_output_stream(file->write_stream);
+  write->offset = &file->offset;
+  write->pollable = &file->write_pollable;
+  write->timeout = 0;
+  write->blocking = true;
   return 0;
 }
 

--- a/libc-bottom-half/sources/wasip2_stdio.c
+++ b/libc-bottom-half/sources/wasip2_stdio.c
@@ -36,10 +36,7 @@ static void stdio_free(void *data) {
   free(stdio);
 }
 
-static int stdio_get_read_stream(void *data,
-                                 streams_borrow_input_stream_t *out_stream,
-                                 off_t **out_offset,
-                                 poll_own_pollable_t **out_pollable) {
+static int stdio_get_read_stream(void *data, wasip2_read_t *read) {
   stdio_t *stdio = (stdio_t *)data;
   if (stdio->fd != 0) {
     errno = EOPNOTSUPP;
@@ -47,18 +44,15 @@ static int stdio_get_read_stream(void *data,
   }
   if (stdio->input.__handle == 0)
     stdio->input = stdin_get_stdin();
-  *out_stream = streams_borrow_input_stream(stdio->input);
-  if (out_offset)
-    *out_offset = NULL;
-  if (out_pollable)
-    *out_pollable = &stdio->input_pollable;
+  read->input = streams_borrow_input_stream(stdio->input);
+  read->offset = NULL;
+  read->pollable = &stdio->input_pollable;
+  read->timeout = 0;
+  read->blocking = true;
   return 0;
 }
 
-static int stdio_get_write_stream(void *data,
-                                  streams_borrow_output_stream_t *out_stream,
-                                  off_t **out_offset,
-                                  poll_own_pollable_t **out_pollable) {
+static int stdio_get_write_stream(void *data, wasip2_write_t *write) {
   stdio_t *stdio = (stdio_t *)data;
   if (stdio->output.__handle == 0) {
     if (stdio->fd == 1) {
@@ -70,11 +64,11 @@ static int stdio_get_write_stream(void *data,
       return -1;
     }
   }
-  *out_stream = streams_borrow_output_stream(stdio->output);
-  if (out_offset)
-    *out_offset = NULL;
-  if (out_pollable)
-    *out_pollable = &stdio->output_pollable;
+  write->output = streams_borrow_output_stream(stdio->output);
+  write->offset = NULL;
+  write->pollable = &stdio->output_pollable;
+  write->blocking = true;
+  write->timeout = 0;
   return 0;
 }
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -319,6 +319,7 @@ if (NOT (WASI STREQUAL "p1"))
   add_wasilibc_test(sockets-nonblocking-multiple.c NETWORK FAILP3)
   add_wasilibc_test(sockets-nonblocking-udp-multiple.c NETWORK FAILP3)
   add_wasilibc_test(sockets-fcntl.c NETWORK)
+  add_wasilibc_test(sockets-udp-connected.c NETWORK FAILP3)
 
   # TODO: flaky tests
   # add_wasilibc_test(sockets-nonblocking.c NETWORK)

--- a/test/src/sockets-udp-connected.c
+++ b/test/src/sockets-udp-connected.c
@@ -1,0 +1,62 @@
+#include "test.h"
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#define TEST(c)                                                                \
+  do {                                                                         \
+    errno = 0;                                                                 \
+    if (!(c))                                                                  \
+      t_error("%s failed (errno = %d)\n", #c, errno);                          \
+  } while (0)
+
+int main() {
+  int socket1 = socket(AF_INET, SOCK_DGRAM, 0);
+  TEST(socket1 != -1);
+  int socket2 = socket(AF_INET, SOCK_DGRAM, 0);
+  TEST(socket2 != -1);
+
+  struct sockaddr_in addr1;
+  addr1.sin_family = AF_INET;
+  addr1.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  addr1.sin_port = htons(0);
+  TEST(bind(socket1, (struct sockaddr *)&addr1, sizeof(addr1)) == 0);
+
+  socklen_t addrlen = sizeof(addr1);
+  TEST(getsockname(socket1, (struct sockaddr *)&addr1, &addrlen) == 0);
+
+  TEST(connect(socket2, (struct sockaddr *)&addr1, sizeof(addr1)) == 0);
+
+  char message[] = "Hello, world!";
+  char buffer[256];
+
+  // send/recv work
+  TEST(send(socket2, message, sizeof(message), 0) == sizeof(message));
+  TEST(recv(socket1, buffer, sizeof(buffer), 0) == sizeof(message));
+  TEST(memcmp(message, buffer, sizeof(message)) == 0);
+
+  // read/write work
+  TEST(write(socket2, message, sizeof(message)) == sizeof(message));
+  TEST(read(socket1, buffer, sizeof(buffer)) == sizeof(message));
+  TEST(memcmp(message, buffer, sizeof(message)) == 0);
+
+  // sendto doesn't work (allowed by posix apparently?) but recfrom does
+  TEST(sendto(socket2, message, sizeof(message), 0, (struct sockaddr *)&addr1,
+              addrlen) == -1 &&
+       errno == EISCONN);
+  TEST(write(socket2, message, sizeof(message)) == sizeof(message));
+  TEST(recvfrom(socket1, buffer, sizeof(buffer), 0, (struct sockaddr *)&addr1,
+                &addrlen) == sizeof(message));
+
+  TEST(close(socket1) == 0);
+  TEST(close(socket2) == 0);
+
+  return t_status;
+}


### PR DESCRIPTION
This commit extends the support in #734 by deduplicating the separate paths for reading a stream shared between `read` and `recvfrom`, for example. The `get_{read,write}_stream` methods now return more metadata and the TCP `recvfrom` implementation delegates to an internal `__wasilibc_read` to perform the actual read. This opens up the door to supporting nonblocking reads/writes on other streams in the future, for example.