### PR TITLE
only signal read (not write) readiness for listening sockets

### DIFF
--- a/test/src/poll-connect.c
+++ b/test/src/poll-connect.c
@@ -99,6 +99,9 @@ int main() {
     }
 
     if (server_client == -1 && fds[1].revents) {
+      // A listening socket should be readable but not writable:
+      ASSERT((fds[1].revents & POLLRDNORM) != 0);
+      ASSERT((fds[1].revents & POLLWRNORM) == 0);
       errno = 0;
       server_client =
           accept(server, (struct sockaddr *)&client_address, &client_len);


### PR DESCRIPTION
This fixes the [reregister_different_interest_without_poll] test in mio.

[reregister_different_interest_without_poll]: https://github.com/tokio-rs/mio/blob/66ac9fab79bf191218488c4f35c99d13935b7e12/tests/registering.rs#L118