### PR TITLE
Enable more build warnings for `libc-bottom-half`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
             os: ubuntu-22.04
             clang_version: 11
             upload: linux-x86_64-clang-11
-            args: -DSETJMP=OFF -DBUILD_SHARED=OFF
+            args: -DSETJMP=OFF -DBUILD_SHARED=OFF -DENABLE_WERROR=OFF
           - name: Build with LLVM 18
             os: ubuntu-24.04
             clang_version: 18
@@ -177,7 +177,7 @@ jobs:
 
     - name: Configure testing
       if: matrix.test
-      run: cmake -S . -B build -DBUILD_TESTS=ON -DENGINE=${{ env.ENGINE }}
+      run: cmake -S . -B build -DENABLE_WERROR=ON -DBUILD_TESTS=ON -DENGINE=${{ env.ENGINE }}
 
     - name: Build
       run: ninja -C build -v

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ option(SIMD "Whether or not to build simd-enabled intrinsics into wasi-libc" OFF
 option(BUILD_SHARED "Whether or not to build shared libraries" ON)
 option(CHECK_SYMBOLS "Whether or not to check the exported symbols of libc.a" OFF)
 set(WASI_SDK_VERSION "" CACHE STRING "Version information for wasi-sdk to embed in headers")
+option(ENABLE_WERROR "Whether to compile with `-Werror`" OFF)
 
 if(TARGET_TRIPLE MATCHES "-threads$")
   set(WASI p1)
@@ -195,24 +196,18 @@ add_compile_options(
   # TODO: Add -fno-signaling-nans when the compiler supports it.
   -fno-trapping-math
 
-  # Add all warnings, but disable a few which occur in third-party code.
-  -Wall -Wextra -Werror
-  -Wno-null-pointer-arithmetic
-  -Wno-unused-parameter
-  -Wno-sign-compare
-  -Wno-unused-variable
-  -Wno-unused-function
-  -Wno-ignored-attributes
-  -Wno-missing-braces
-  -Wno-ignored-pragmas
-  -Wno-unused-but-set-variable
-  -Wno-unknown-warning-option
-  -Wno-unterminated-string-initialization
+  # Add all warnings. Note that third-party code is compiled with extra flags
+  # to disable warnings that crop up.
+  -Wall -Wextra
 
   # Compiling assembly flags lots of arguments as unused but that's not too
   # interesting so just ignore that.
   $<$<COMPILE_LANGUAGE:ASM>:-Wno-unused-command-line-argument>
 )
+
+if (ENABLE_WERROR)
+  add_compile_options(-Werror)
+endif()
 
 # =============================================================================
 # Helper functions for adding libraries.

--- a/dlmalloc/CMakeLists.txt
+++ b/dlmalloc/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Disable some warnings in this third-party code.
+add_compile_options(-Wno-null-pointer-arithmetic -Wno-unused-but-set-variable)
+
 add_object_library(dlmalloc src/dlmalloc.c)
 foreach(obj dlmalloc-shared dlmalloc-static)
   target_include_directories(${obj} PRIVATE include)

--- a/emmalloc/CMakeLists.txt
+++ b/emmalloc/CMakeLists.txt
@@ -1,3 +1,5 @@
+# Disable some warnings in this third-party code.
+add_compile_options(-Wno-unused-function)
 add_object_library(emmalloc emmalloc.c)
 
 # emmalloc uses a lot of pointer type-punning, which is UB under strict

--- a/fts/CMakeLists.txt
+++ b/fts/CMakeLists.txt
@@ -1,3 +1,6 @@
+# Disable some warnings in this third-party code.
+add_compile_options(-Wno-unused-parameter -Wno-unused-variable)
+
 add_internal_object_library(fts musl-fts/fts.c)
 foreach(obj fts-shared fts-static)
   target_include_directories(${obj} PRIVATE . musl-fts)

--- a/libc-bottom-half/cloudlibc/src/common/errors.h
+++ b/libc-bottom-half/cloudlibc/src/common/errors.h
@@ -4,7 +4,7 @@
 #include <errno.h>
 #include <stdlib.h>
 
-static void translate_error(filesystem_error_code_t error) {
+static inline void translate_error(filesystem_error_code_t error) {
     switch (error) {
     case FILESYSTEM_ERROR_CODE_ACCESS:
         errno = EACCES;

--- a/libc-bottom-half/cloudlibc/src/libc/dirent/fdopendir.c
+++ b/libc-bottom-half/cloudlibc/src/libc/dirent/fdopendir.c
@@ -77,6 +77,7 @@ DIR *fdopendir(int fd) {
   dirp->dirent_size = 1;
   return dirp;
 #elif defined(__wasip3__)
+  (void) fd;
   // TODO(wasip3)
   errno = ENOTSUP;
   free(dirp);

--- a/libc-bottom-half/cloudlibc/src/libc/dirent/readdir.c
+++ b/libc-bottom-half/cloudlibc/src/libc/dirent/readdir.c
@@ -32,6 +32,7 @@ static_assert(DT_UNKNOWN == __WASI_FILETYPE_UNKNOWN, "Value mismatch");
 #endif
 
 // Grows a buffer to be large enough to hold a certain amount of data.
+#ifndef __wasip3__
 static struct dirent* grow(struct dirent **buffer, size_t *buffer_size, size_t target_size) {
   if (*buffer_size < target_size) {
     size_t new_size = *buffer_size;
@@ -47,6 +48,7 @@ static struct dirent* grow(struct dirent **buffer, size_t *buffer_size, size_t t
   }
   return *buffer;
 }
+#endif
 
 #if defined(__wasip1__)
 struct dirent *readdir(DIR *dirp) {

--- a/libc-bottom-half/cloudlibc/src/libc/dirent/scandirat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/dirent/scandirat.c
@@ -8,10 +8,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-static int sel_true(const struct dirent *de) {
-  return 1;
-}
-
 int __wasilibc_nocwd_scandirat(int dirfd, const char *dir, struct dirent ***res,
                                int (*sel)(const struct dirent *),
                                int (*cmp)(const struct dirent **, const struct dirent **)) {

--- a/libc-bottom-half/cloudlibc/src/libc/fcntl/openat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/fcntl/openat.c
@@ -162,6 +162,9 @@ int __wasilibc_nocwd_openat_nomode(int fd, const char *path, int oflag) {
   // Update the descriptor table with the new handle
   return __wasilibc_add_file(new_handle, oflag);
 #elif defined(__wasip3__)
+  (void) fd;
+  (void) path;
+  (void) oflag;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/fcntl/posix_fadvise.c
+++ b/libc-bottom-half/cloudlibc/src/libc/fcntl/posix_fadvise.c
@@ -72,6 +72,8 @@ int posix_fadvise(int fd, off_t offset, off_t len, int advice) {
   }
   return 0;
 #elif defined(__wasip3__)
+  (void) fd;
+  (void) advice;
   // TODO(wasip3)
   errno = ENOTSUP;
   return ENOTSUP;

--- a/libc-bottom-half/cloudlibc/src/libc/fcntl/posix_fallocate.c
+++ b/libc-bottom-half/cloudlibc/src/libc/fcntl/posix_fallocate.c
@@ -7,11 +7,12 @@
 #include <fcntl.h>
 
 int posix_fallocate(int fd, off_t offset, off_t len) {
-#if defined(__wasip1__)
   if (offset < 0 || len < 0)
     return EINVAL;
+#if defined(__wasip1__)
   return __wasi_fd_allocate(fd, offset, len);
 #elif defined(__wasip2__) || defined(__wasip3__)
+  (void) fd;
   // Note: this operation isn't supported in wasip{2,3}
   return ENOTSUP;
 #else

--- a/libc-bottom-half/cloudlibc/src/libc/poll/poll.c
+++ b/libc-bottom-half/cloudlibc/src/libc/poll/poll.c
@@ -216,7 +216,6 @@ static int poll_impl(struct pollfd *fds, size_t nfds, int timeout) {
 
     if (pollfd->events & POLLRDNORM) {
       if (entry->vtable->get_read_stream) {
-        streams_borrow_input_stream_t input;
         wasip2_read_t read;
         if (entry->vtable->get_read_stream(entry->data, &read) < 0)
           return -1;
@@ -285,6 +284,9 @@ static int poll_impl(struct pollfd *fds, size_t nfds, int timeout) {
 #elif defined(__wasip3__)
 
 static int poll_impl(struct pollfd *fds, size_t nfds, int timeout) {
+  (void) fds;
+  (void) nfds;
+  (void) timeout;
   errno = ENOTSUP;
   return -1;
 }

--- a/libc-bottom-half/cloudlibc/src/libc/stdio/renameat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/stdio/renameat.c
@@ -48,6 +48,10 @@ int __wasilibc_nocwd_renameat(int oldfd, const char *old, int newfd, const char 
     return -1;
   }
 #elif defined(__wasip3__)
+  (void) oldfd;
+  (void) old;
+  (void) newfd;
+  (void) new;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/sys/select/pselect.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/select/pselect.c
@@ -13,6 +13,7 @@
 int pselect(int nfds, fd_set *restrict readfds, fd_set *restrict writefds,
             fd_set *restrict errorfds, const struct timespec *restrict timeout,
             const sigset_t *sigmask) {
+  (void) sigmask;
   // Negative file descriptor upperbound.
   if (nfds < 0) {
     errno = EINVAL;

--- a/libc-bottom-half/cloudlibc/src/libc/sys/stat/fstat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/stat/fstat.c
@@ -25,6 +25,8 @@ int fstat(int fildes, struct stat *buf) {
     return -1;
   return entry->vtable->fstat(entry->data, buf);
 #elif defined(__wasip3__)
+  (void) fildes;
+  (void) buf;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/sys/stat/fstatat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/stat/fstatat.c
@@ -81,6 +81,10 @@ int __wasilibc_nocwd_fstatat(int fd, const char *restrict path, struct stat *res
   to_public_stat(&metadata, &internal_stat, buf);
   return 0;
 #elif defined(__wasip3__)
+  (void) fd;
+  (void) path;
+  (void) buf;
+  (void) flag;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/sys/stat/futimens.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/stat/futimens.c
@@ -53,6 +53,8 @@ int futimens(int fd, const struct timespec *times) {
     return -1;
   }
 #elif defined(__wasip3__)
+  (void) fd;
+  (void) times;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/sys/stat/mkdirat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/stat/mkdirat.c
@@ -41,6 +41,8 @@ int __wasilibc_nocwd_mkdirat_nomode(int fd, const char *path) {
   }
   return 0;
 #elif defined(__wasip3__)
+  (void) fd;
+  (void) path;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/sys/stat/utimensat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/stat/utimensat.c
@@ -75,6 +75,10 @@ int __wasilibc_nocwd_utimensat(int fd, const char *path, const struct timespec t
     return -1;
   }
 #elif defined(__wasip3__)
+  (void) fd;
+  (void) path;
+  (void) times;
+  (void) flag;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/sys/time/gettimeofday.c
+++ b/libc-bottom-half/cloudlibc/src/libc/sys/time/gettimeofday.c
@@ -7,6 +7,7 @@
 #include <wasi/api.h>
 
 int gettimeofday(struct timeval *restrict tp, void *tz) {
+  (void) tz;
   if (tp != NULL) {
 #if defined(__wasip1__)
     __wasi_timestamp_t ts = 0;

--- a/libc-bottom-half/cloudlibc/src/libc/time/clock_nanosleep.c
+++ b/libc-bottom-half/cloudlibc/src/libc/time/clock_nanosleep.c
@@ -19,6 +19,7 @@ static_assert(TIMER_ABSTIME == __WASI_SUBCLOCKFLAGS_SUBSCRIPTION_CLOCK_ABSTIME,
 
 int clock_nanosleep(clockid_t clock_id, int flags, const struct timespec *rqtp,
                     struct timespec *rmtp) {
+  (void) rmtp;
   if ((flags & ~TIMER_ABSTIME) != 0)
     return EINVAL;
 
@@ -38,7 +39,6 @@ int clock_nanosleep(clockid_t clock_id, int flags, const struct timespec *rqtp,
   __wasi_errno_t error = __wasi_poll_oneoff(&sub, &ev, 1, &nevents);
   return error == 0 && ev.error == 0 ? 0 : ENOTSUP;
 #elif defined(__wasip2__) || defined(__wasip3__)
-  // Note: rmtp is ignored
 
   if (clock_id != CLOCK_MONOTONIC) {
     // wasip{2,3} only provide a pollable for monotonic clocks

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/faccessat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/faccessat.c
@@ -110,6 +110,8 @@ int __wasilibc_nocwd_faccessat(int fd, const char *path, int amode, int flag) {
     }
   }
 #elif defined(__wasip3__)
+  (void) fd;
+  (void) path;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/fdatasync.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/fdatasync.c
@@ -32,6 +32,7 @@ int fdatasync(int fildes) {
     return -1;
   }
 #elif defined(__wasip3__)
+  (void) fildes;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/fsync.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/fsync.c
@@ -31,6 +31,7 @@ int fsync(int fildes) {
     return -1;
   }
 #elif defined(__wasip3__)
+  (void) fildes;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/ftruncate.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/ftruncate.c
@@ -36,6 +36,7 @@ int ftruncate(int fildes, off_t length) {
     return -1;
   }
 #elif defined(__wasip3__)
+  (void) fildes;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/linkat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/linkat.c
@@ -43,8 +43,11 @@ int __wasilibc_nocwd_linkat(int fd1, const char *path1, int fd2, const char *pat
 
   // Create the link
   filesystem_error_code_t error_code;
+  filesystem_path_flags_t flags = 0;
+  if ((flag & AT_SYMLINK_FOLLOW) != 0)
+    flags |= FILESYSTEM_PATH_FLAGS_SYMLINK_FOLLOW;
   bool ok = filesystem_method_descriptor_link_at(file_handle1,
-                                                 0,
+                                                 flags,
                                                  &path1_wasi,
                                                  file_handle2,
                                                  &path2_wasi,
@@ -54,6 +57,11 @@ int __wasilibc_nocwd_linkat(int fd1, const char *path1, int fd2, const char *pat
     return -1;
   }
 #elif defined(__wasip3__)
+  (void) fd1;
+  (void) path1;
+  (void) fd2;
+  (void) path2;
+  (void) flag;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/lseek.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/lseek.c
@@ -40,6 +40,9 @@ off_t __lseek(int fildes, off_t offset, int whence) {
   }
   return entry->vtable->seek(entry->data, offset, whence);
 #elif defined(__wasip3__)
+  (void) fildes;
+  (void) offset;
+  (void) whence;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/pread.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/pread.c
@@ -66,6 +66,9 @@ ssize_t pread(int fildes, void *buf, size_t nbyte, off_t offset) {
 
   return bytes_read;
 #elif defined(__wasip3__)
+  (void) fildes;
+  (void) buf;
+  (void) nbyte;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/pwrite.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/pwrite.c
@@ -62,6 +62,9 @@ ssize_t pwrite(int fildes, const void *buf, size_t nbyte, off_t offset) {
 
   return bytes_written;
 #elif defined(__wasip3__)
+  (void) fildes;
+  (void) buf;
+  (void) nbyte;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/readlinkat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/readlinkat.c
@@ -50,6 +50,10 @@ ssize_t __wasilibc_nocwd_readlinkat(int fd, const char *restrict path, char *res
   memcpy(buf, link_source.ptr, bufused);
   wasip2_string_free(&link_source);
 #elif defined(__wasip3__)
+  (void) fd;
+  (void) path;
+  (void) buf;
+  (void) bufsize;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/cloudlibc/src/libc/unistd/symlinkat.c
+++ b/libc-bottom-half/cloudlibc/src/libc/unistd/symlinkat.c
@@ -45,6 +45,9 @@ int __wasilibc_nocwd_symlinkat(const char *path1, int fd, const char *path2) {
     return -1;
   }
 #elif defined(__wasip3__)
+  (void) path1;
+  (void) path2;
+  (void) fd;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/headers/private/wasi/file_utils.h
+++ b/libc-bottom-half/headers/private/wasi/file_utils.h
@@ -17,7 +17,7 @@
 ///
 /// If the error indicates "closed" then 0 is returned to mean EOF. Otherwise
 /// the last-operation-failed handle is closed and errno is set to EIO.
-static int wasip2_handle_read_error(streams_stream_error_t error) {
+static inline int wasip2_handle_read_error(streams_stream_error_t error) {
   if (error.tag == STREAMS_STREAM_ERROR_CLOSED) {
     return 0;
   }
@@ -29,7 +29,7 @@ static int wasip2_handle_read_error(streams_stream_error_t error) {
 
 /// Same as `wasip2_handle_read_error` except "closed" now returns EPIPE
 /// instead of 0.
-static int wasip2_handle_write_error(streams_stream_error_t error) {
+static inline int wasip2_handle_write_error(streams_stream_error_t error) {
   if (error.tag == STREAMS_STREAM_ERROR_CLOSED) {
     errno = EPIPE;
     return -1;
@@ -52,7 +52,7 @@ int wasip2_string_from_c(const char *s, wasip2_string_t* out);
 
 #if defined(__wasip2__) || defined(__wasip3__)
 // Succeed only if fd is bound to a file handle in the descriptor table
-static int fd_to_file_handle(int fd, filesystem_borrow_descriptor_t* result) {
+static inline int fd_to_file_handle(int fd, filesystem_borrow_descriptor_t* result) {
   descriptor_table_entry_t* entry = descriptor_table_get_ref(fd);
   if (entry == NULL)
     return -1;
@@ -81,7 +81,7 @@ int __wasilibc_read_stream3(int fildes, filesystem_tuple2_stream_u8_future_resul
 #endif
 
 #if defined(__wasip2__) || defined(__wasip3__)
-static unsigned dir_entry_type_to_d_type(filesystem_descriptor_type_t ty) {
+static inline unsigned dir_entry_type_to_d_type(filesystem_descriptor_type_t ty) {
   switch(ty) {
   case FILESYSTEM_DESCRIPTOR_TYPE_UNKNOWN:
     return DT_UNKNOWN;

--- a/libc-bottom-half/headers/private/wasi/poll.h
+++ b/libc-bottom-half/headers/private/wasi/poll.h
@@ -33,7 +33,7 @@ int __wasilibc_poll_add(poll_state_t *state,
 
 /// Helper function to lazily subscribe to an input stream and call
 /// `__wasilibc_poll_add`.
-static int __wasilibc_poll_add_input_stream(
+static inline int __wasilibc_poll_add_input_stream(
     poll_state_t *state,
     streams_borrow_input_stream_t input_stream,
     poll_own_pollable_t *pollable) {
@@ -44,7 +44,7 @@ static int __wasilibc_poll_add_input_stream(
 
 /// Helper function to lazily subscribe to an output stream and call
 /// `__wasilibc_poll_add`.
-static int __wasilibc_poll_add_output_stream(
+static inline int __wasilibc_poll_add_output_stream(
     poll_state_t *state,
     streams_borrow_output_stream_t output_stream,
     poll_own_pollable_t *pollable) {

--- a/libc-bottom-half/signal/CMakeLists.txt
+++ b/libc-bottom-half/signal/CMakeLists.txt
@@ -1,3 +1,4 @@
+add_compile_options(-Wno-unused-function)
 add_internal_object_library(top-half-emulated-signal
     ../../libc-top-half/musl/src/signal/psignal.c
     ../../libc-top-half/musl/src/string/strsignal.c)

--- a/libc-bottom-half/signal/signal.c
+++ b/libc-bottom-half/signal/signal.c
@@ -14,10 +14,14 @@
 #include <string.h>
 
 void __SIG_IGN(int sig) {
+  (void)sig;
   // do nothing
 }
 
-_Noreturn void __SIG_ERR(int sig) { __builtin_trap(); }
+_Noreturn void __SIG_ERR(int sig) {
+  (void)sig;
+  __builtin_trap();
+}
 
 _Noreturn static void core_handler(int sig) {
   fprintf(stderr, "Program received fatal signal: %s\n", strsignal(sig));
@@ -35,6 +39,7 @@ _Noreturn static void stop_handler(int sig) {
 }
 
 static void continue_handler(int sig) {
+  (void)sig;
   // do nothing
 }
 

--- a/libc-bottom-half/sources/__wasilibc_real.c
+++ b/libc-bottom-half/sources/__wasilibc_real.c
@@ -610,7 +610,4 @@ int32_t __wasi_thread_spawn(void *start_arg) {
 }
 #endif
 
-#else
-// Suppress the "no symbols" linker error
-static void __wasi_noop() {}
-#endif // __wasip2__
+#endif // __wasip1__

--- a/libc-bottom-half/sources/__wasilibc_rmdirat.c
+++ b/libc-bottom-half/sources/__wasilibc_rmdirat.c
@@ -35,6 +35,8 @@ int __wasilibc_nocwd___wasilibc_rmdirat(int fd, const char *path) {
     return -1;
   }
 #elif defined(__wasip3__)
+  (void)fd;
+  (void)path;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/sources/__wasilibc_tell.c
+++ b/libc-bottom-half/sources/__wasilibc_tell.c
@@ -30,6 +30,7 @@ off_t __wasilibc_tell(int fildes) {
   }
   return entry->vtable->seek(entry->data, 0, SEEK_CUR);
 #elif defined(__wasip3__)
+  (void)fildes;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/sources/__wasilibc_unlinkat.c
+++ b/libc-bottom-half/sources/__wasilibc_unlinkat.c
@@ -48,6 +48,8 @@ int __wasilibc_nocwd___wasilibc_unlinkat(int fd, const char *path) {
 
   return 0;
 #elif defined(__wasip3__)
+  (void)fd;
+  (void)path;
   // TODO(wasip3)
   errno = ENOTSUP;
   return -1;

--- a/libc-bottom-half/sources/descriptor_table.c
+++ b/libc-bottom-half/sources/descriptor_table.c
@@ -25,7 +25,7 @@ typedef struct {
   // Dynamically allocated array of `cap` entries.
   descriptor_table_item_t *entries;
   // Next free entry.
-  int next;
+  size_t next;
   // Number of `entries` that are initialized.
   size_t len;
   // Dynamic length of `entries`.
@@ -34,7 +34,6 @@ typedef struct {
 
 static descriptor_table_t global_table = {
     .entries = NULL, .next = 0, .len = 0, .cap = 0};
-static int global_table_stdio_initialized = 0;
 
 /**
  * Allocates a new `descriptor_table_entry_t` in the `table` provided.

--- a/libc-bottom-half/sources/netdb.c
+++ b/libc-bottom-half/sources/netdb.c
@@ -250,22 +250,34 @@ void freeaddrinfo(struct addrinfo *p) {
 int getnameinfo(const struct sockaddr *restrict sa, socklen_t salen,
                 char *restrict host, socklen_t hostlen, char *restrict serv,
                 socklen_t servlen, int flags) {
+  (void)sa;
+  (void)salen;
+  (void)host;
+  (void)hostlen;
+  (void)serv;
+  (void)servlen;
+  (void)flags;
   // TODO wasi-sockets
   errno = EOPNOTSUPP;
   return EAI_SYSTEM;
 }
 
 struct hostent *gethostbyname(const char *name) {
+  (void)name;
   // TODO wasi-sockets
   return NULL;
 }
 
 struct hostent *gethostbyaddr(const void *addr, socklen_t len, int type) {
+  (void)addr;
+  (void)len;
+  (void)type;
   // TODO wasi-sockets
   return NULL;
 }
 
 const char *hstrerror(int err) {
+  (void)err;
   // TODO wasi-sockets
   return "hstrerror: TODO";
 }
@@ -288,6 +300,7 @@ struct servent *getservbyport(int port, const char *proto) {
 }
 
 struct protoent *getprotobyname(const char *name) {
+  (void)name;
   // TODO wasi-sockets
   return NULL;
 }

--- a/libc-bottom-half/sources/posix.c
+++ b/libc-bottom-half/sources/posix.c
@@ -211,6 +211,7 @@ int remove(const char *path) {
 }
 
 int mkdir(const char *path, mode_t mode) {
+  (void)mode;
   char *relative_path;
   int dirfd = find_relpath(path, &relative_path);
 
@@ -302,6 +303,8 @@ int rename(const char *old, const char *new) {
 }
 
 int chmod(const char *path, mode_t mode) {
+  (void)path;
+  (void)mode;
   // TODO: We plan to support this eventually in WASI, but not yet.
   // Meanwhile, we provide a stub so that libc++'s `<filesystem>`
   // implementation will build unmodified.
@@ -310,6 +313,8 @@ int chmod(const char *path, mode_t mode) {
 }
 
 int fchmod(int fd, mode_t mode) {
+  (void)fd;
+  (void)mode;
   // TODO: We plan to support this eventually in WASI, but not yet.
   // Meanwhile, we provide a stub so that libc++'s `<filesystem>`
   // implementation will build unmodified.
@@ -318,6 +323,10 @@ int fchmod(int fd, mode_t mode) {
 }
 
 int fchmodat(int fd, const char *path, mode_t mode, int flag) {
+  (void)fd;
+  (void)path;
+  (void)mode;
+  (void)flag;
   // TODO: We plan to support this eventually in WASI, but not yet.
   // Meanwhile, we provide a stub so that libc++'s `<filesystem>`
   // implementation will build unmodified.
@@ -326,6 +335,8 @@ int fchmodat(int fd, const char *path, mode_t mode, int flag) {
 }
 
 int statvfs(const char *__restrict path, struct statvfs *__restrict buf) {
+  (void)path;
+  (void)buf;
   // TODO: We plan to support this eventually in WASI, but not yet.
   // Meanwhile, we provide a stub so that libc++'s `<filesystem>`
   // implementation will build unmodified.
@@ -334,6 +345,8 @@ int statvfs(const char *__restrict path, struct statvfs *__restrict buf) {
 }
 
 int fstatvfs(int fd, struct statvfs *buf) {
+  (void)fd;
+  (void)buf;
   // TODO: We plan to support this eventually in WASI, but not yet.
   // Meanwhile, we provide a stub so that libc++'s `<filesystem>`
   // implementation will build unmodified.

--- a/libc-bottom-half/sources/preopens.c
+++ b/libc-bottom-half/sources/preopens.c
@@ -29,13 +29,16 @@ typedef struct {
 typedef __wasi_fd_t preopen_t;
 
 static void assert_preopen_valid(preopen_t fd) {
+  (void)fd;
   assert(fd != AT_FDCWD);
   assert(fd != -1);
 }
 
+#ifndef NDEBUG
 static void preopen_state_assert_open(const preopen_state_t *state) {
   assert(state->fd != -1);
 }
+#endif
 
 static int preopen_state_initialize(preopen_state_t *state, preopen_t fd) {
   state->fd = fd;
@@ -46,7 +49,7 @@ static int preopen_state_get_fd(const preopen_state_t *state) {
   return state->fd;
 }
 
-static void preopen_state_close(preopen_state_t *state) {}
+static void preopen_state_close(preopen_state_t *state) { (void)state; }
 
 #elif defined(__wasip2__) || defined(__wasip3__)
 
@@ -56,11 +59,16 @@ typedef struct {
 
 typedef filesystem_preopens_own_descriptor_t preopen_t;
 
-static void assert_preopen_valid(preopen_t fd) { assert(fd.__handle != 0); }
+static void assert_preopen_valid(preopen_t fd) {
+  (void)fd;
+  assert(fd.__handle != 0);
+}
 
+#ifndef NDEBUG
 static void preopen_state_assert_open(const preopen_state_t *state) {
   assert(state->libc_fd != -1);
 }
+#endif
 
 static int preopen_state_initialize(preopen_state_t *state, preopen_t fd) {
   state->libc_fd = __wasilibc_add_file(fd, O_RDWR);
@@ -396,7 +404,7 @@ void __wasilibc_reset_preopens(void) {
   LOCK(lock);
 
   if (num_preopens) {
-    for (int i = 0; i < num_preopens; ++i) {
+    for (unsigned i = 0; i < num_preopens; ++i) {
       free((void *)preopens[i].prefix);
       preopen_state_close(&preopens[i].state);
     }

--- a/libc-bottom-half/sources/sockets_utils.c
+++ b/libc-bottom-half/sources/sockets_utils.c
@@ -40,7 +40,6 @@ typedef network_ipv6_address_t sockets_ipv6_address_t;
 typedef network_ip_socket_address_t sockets_ip_socket_address_t;
 #endif
 
-static bool global_network_initialized = false;
 static const service_entry_t global_services[] = {
     {"domain", 53, SERVICE_PROTOCOL_TCP | SERVICE_PROTOCOL_UDP},
     {"ftp", 21, SERVICE_PROTOCOL_TCP},
@@ -65,6 +64,7 @@ weak_alias(global_services, __wasi_sockets_services_db);
 
 #ifdef __wasip2__
 static network_own_network_t global_network;
+static bool global_network_initialized = false;
 
 network_borrow_network_t __wasi_sockets_utils__borrow_network() {
   if (!global_network_initialized) {

--- a/libc-bottom-half/sources/tcp.c
+++ b/libc-bottom-half/sources/tcp.c
@@ -160,7 +160,7 @@ static int tcp_set_blocking(void *data, bool blocking) {
 }
 
 static int tcp_fstat(void *data, struct stat *buf) {
-  tcp_socket_t *tcp = (tcp_socket_t *)data;
+  (void)data;
   memset(buf, 0, sizeof(struct stat));
   buf->st_mode = S_IFSOCK;
   return 0;
@@ -195,10 +195,7 @@ static int tcp_accept4(void *data, struct sockaddr *addr, socklen_t *addrlen,
     return -1;
   }
 
-  tcp_socket_state_listening_t listener;
-  if (socket->state.tag == TCP_SOCKET_STATE_LISTENING) {
-    listener = socket->state.listening;
-  } else {
+  if (socket->state.tag != TCP_SOCKET_STATE_LISTENING) {
     errno = EINVAL;
     return -1;
   }
@@ -325,11 +322,10 @@ static int tcp_connect(void *data, const struct sockaddr *addr,
     return -1;
   }
 
-  sockets_error_code_t error;
+#ifdef __wasip2__
   sockets_borrow_tcp_socket_t socket_borrow =
       sockets_borrow_tcp_socket(socket->socket);
-
-#ifdef __wasip2__
+  sockets_error_code_t error;
   network_borrow_network_t network_borrow =
       __wasi_sockets_utils__borrow_network();
 
@@ -498,8 +494,6 @@ static int tcp_listen(void *data, int backlog) {
   }
 
 #ifdef __wasip2__
-  network_borrow_network_t network_borrow =
-      __wasi_sockets_utils__borrow_network();
   if (!tcp_method_tcp_socket_start_listen(socket_borrow, &error)) {
     return __wasilibc_socket_error_to_errno(error);
   }
@@ -519,7 +513,6 @@ static int tcp_listen(void *data, int backlog) {
 #ifdef __wasip2__
 static ssize_t tcp_recvfrom(void *data, void *buffer, size_t length, int flags,
                             struct sockaddr *addr, socklen_t *addrlen) {
-  tcp_socket_t *socket = (tcp_socket_t *)data;
   // TODO wasi-sockets: flags:
   // - MSG_WAITALL: we can probably support these relatively easy.
   // - MSG_OOB: could be shimmed by always responding that no OOB data is
@@ -551,7 +544,6 @@ static ssize_t tcp_recvfrom(void *data, void *buffer, size_t length, int flags,
 static ssize_t tcp_sendto(void *data, const void *buffer, size_t length,
                           int flags, const struct sockaddr *addr,
                           socklen_t addrlen) {
-  tcp_socket_t *socket = (tcp_socket_t *)data;
   const int supported_flags = MSG_DONTWAIT | MSG_NOSIGNAL;
   if ((flags & supported_flags) != flags) {
     errno = EOPNOTSUPP;
@@ -597,10 +589,7 @@ static int tcp_shutdown(void *data, int posix_how) {
     return -1;
   }
 
-  tcp_socket_state_connected_t *connection;
-  if (socket->state.tag == TCP_SOCKET_STATE_CONNECTED) {
-    connection = &socket->state.connected;
-  } else {
+  if (socket->state.tag != TCP_SOCKET_STATE_CONNECTED) {
     errno = ENOTCONN;
     return -1;
   }
@@ -932,6 +921,10 @@ static int tcp_getsockopt(void *data, int level, int optname,
 static int tcp_setsockopt(void *data, int level, int optname,
                           const void *optval, socklen_t optlen) {
   tcp_socket_t *socket = (tcp_socket_t *)data;
+  if (optlen < sizeof(int)) {
+    errno = EINVAL;
+    return -1;
+  }
   int intval = *(int *)optval;
 
   sockets_error_code_t error;
@@ -971,6 +964,10 @@ static int tcp_setsockopt(void *data, int level, int optname,
       return 0;
     }
     case SO_RCVTIMEO: {
+      if (optlen < sizeof(struct timeval)) {
+        errno = EINVAL;
+        return -1;
+      }
       struct timeval *tv = (struct timeval *)optval;
       if (!timeval_to_duration(tv, &socket->recv_timeout)) {
         errno = EINVAL;
@@ -979,6 +976,10 @@ static int tcp_setsockopt(void *data, int level, int optname,
       return 0;
     }
     case SO_SNDTIMEO: {
+      if (optlen < sizeof(struct timeval)) {
+        errno = EINVAL;
+        return -1;
+      }
       struct timeval *tv = (struct timeval *)optval;
       if (!timeval_to_duration(tv, &socket->send_timeout)) {
         errno = EINVAL;

--- a/libc-bottom-half/sources/udp.c
+++ b/libc-bottom-half/sources/udp.c
@@ -91,6 +91,7 @@ int __wasilibc_add_udp_socket(sockets_own_udp_socket_t socket,
   return descriptor_table_insert(entry);
 }
 
+#ifdef __wasip2__
 static int udp_create_streams(udp_socket_t *socket,
                               sockets_ip_socket_address_t *remote_address) {
   // Assert that:
@@ -102,9 +103,6 @@ static int udp_create_streams(udp_socket_t *socket,
     abort();
   }
 
-  sockets_borrow_udp_socket_t socket_borrow =
-      sockets_borrow_udp_socket(socket->socket);
-
   udp_socket_streams_t *dst;
   if (remote_address != NULL) {
     dst = &socket->state.connected.streams;
@@ -115,7 +113,8 @@ static int udp_create_streams(udp_socket_t *socket,
   memset(dst, 0, sizeof(*dst));
 
   sockets_error_code_t error;
-#ifdef __wasip2__
+  sockets_borrow_udp_socket_t socket_borrow =
+      sockets_borrow_udp_socket(socket->socket);
   udp_tuple2_own_incoming_datagram_stream_own_outgoing_datagram_stream_t io;
   if (!udp_method_udp_socket_stream(socket_borrow, remote_address, &io, &error))
     return __wasilibc_socket_error_to_errno(error);
@@ -130,11 +129,8 @@ static int udp_create_streams(udp_socket_t *socket,
   }
 
   return 0;
-#else
-  errno = ENOTSUP;
-  return -1;
-#endif
 }
+#endif
 
 static void udp_close_streams(udp_socket_streams_t *streams) {
 #ifdef __wasip2__
@@ -144,6 +140,8 @@ static void udp_close_streams(udp_socket_streams_t *streams) {
   if (streams->outgoing_pollable.__handle != 0)
     poll_pollable_drop_own(streams->outgoing_pollable);
   udp_outgoing_datagram_stream_drop_own(streams->outgoing);
+#else
+  (void)streams;
 #endif
 }
 
@@ -177,7 +175,7 @@ static int udp_set_blocking(void *data, bool blocking) {
 }
 
 static int udp_fstat(void *data, struct stat *buf) {
-  udp_socket_t *udp = (udp_socket_t *)data;
+  (void)data;
   memset(buf, 0, sizeof(struct stat));
   buf->st_mode = S_IFSOCK;
   return 0;
@@ -404,7 +402,6 @@ static ssize_t udp_recvfrom(void *data, void *buffer, size_t length, int flags,
     return -1;
 
   network_error_code_t error;
-  udp_borrow_udp_socket_t socket_borrow = udp_borrow_udp_socket(socket->socket);
 
   // Make sure the streams are available.
   if (socket->state.tag == UDP_SOCKET_STATE_BOUND_NOSTREAMS)
@@ -501,7 +498,6 @@ static ssize_t udp_sendto(void *data, const void *buffer, size_t length,
   }
 
   network_error_code_t error;
-  udp_borrow_udp_socket_t socket_borrow = udp_borrow_udp_socket(socket->socket);
 
   // If the socket is not explicitly bound by the user we'll do it for them
   if (socket->state.tag == UDP_SOCKET_STATE_UNBOUND) {
@@ -708,6 +704,10 @@ static int udp_getsockopt(void *data, int level, int optname, void *optval,
 static int udp_setsockopt(void *data, int level, int optname,
                           const void *optval, socklen_t optlen) {
   udp_socket_t *socket = (udp_socket_t *)data;
+  if (optlen < sizeof(int)) {
+    errno = EINVAL;
+    return -1;
+  }
   int intval = *(int *)optval;
 
   network_error_code_t error;

--- a/libc-bottom-half/sources/wasip2_stdio.c
+++ b/libc-bottom-half/sources/wasip2_stdio.c
@@ -73,6 +73,7 @@ static int stdio_get_write_stream(void *data, wasip2_write_t *write) {
 }
 
 static int stdio_fstat(void *data, struct stat *buf) {
+  (void)data;
   memset(buf, 0, sizeof(*buf));
   return 0;
 }

--- a/libc-bottom-half/sources/wasip3_file.c
+++ b/libc-bottom-half/sources/wasip3_file.c
@@ -4,6 +4,8 @@
 #ifdef __wasip3__
 
 int __wasilibc_add_file(filesystem_own_descriptor_t file_handle, int oflag) {
+  (void)file_handle;
+  (void)oflag;
   // TODO(wasip3)
   errno = EOPNOTSUPP;
   return -1;

--- a/libc-bottom-half/sources/wasip3_stdio.c
+++ b/libc-bottom-half/sources/wasip3_stdio.c
@@ -81,13 +81,20 @@ stdin3_read(void *data,
 }
 
 static int stdio3_fstat(void *data, struct stat *buf) {
+  (void)data;
   memset(buf, 0, sizeof(*buf));
   return 0;
 }
 
-static int stdin3_fcntl_getfl(void *data) { return O_RDONLY; }
+static int stdin3_fcntl_getfl(void *data) {
+  (void)data;
+  return O_RDONLY;
+}
 
-static int stdout3_fcntl_getfl(void *data) { return O_WRONLY; }
+static int stdout3_fcntl_getfl(void *data) {
+  (void)data;
+  return O_WRONLY;
+}
 
 static int stdin3_isatty(void *data) {
   stdin3_t *stdio = (stdin3_t *)data;

--- a/libc-top-half/CMakeLists.txt
+++ b/libc-top-half/CMakeLists.txt
@@ -1,3 +1,22 @@
+# Disable some warnings in this third-party code.
+add_compile_options(
+  -Wno-bitwise-op-parentheses
+  -Wno-dangling-else
+  -Wno-ignored-attributes
+  -Wno-ignored-pragmas
+  -Wno-logical-op-parentheses
+  -Wno-missing-braces
+  -Wno-parentheses
+  -Wno-shift-op-parentheses
+  -Wno-sign-compare
+  -Wno-string-plus-int
+  -Wno-unknown-pragmas
+  -Wno-unused-but-set-variable
+  -Wno-unused-function
+  -Wno-unused-parameter
+  -Wno-unused-variable
+)
+
 # Dummy interface library which helps configure headers/options for internal
 # libraries below.
 add_library(musl-top-half-interface INTERFACE)
@@ -7,14 +26,6 @@ target_include_directories(musl-top-half-interface INTERFACE
   musl/arch/wasm32
   musl/arch/generic
   headers/private)
-target_compile_options(musl-top-half-interface INTERFACE
-  -Wno-parentheses
-  -Wno-shift-op-parentheses
-  -Wno-bitwise-op-parentheses
-  -Wno-logical-op-parentheses
-  -Wno-string-plus-int
-  -Wno-dangling-else
-  -Wno-unknown-pragmas)
 add_dependencies(musl-top-half-interface sysroot_inc)
 
 # =============================================================================

--- a/libc-top-half/musl/src/internal/pthread_impl.h
+++ b/libc-top-half/musl/src/internal/pthread_impl.h
@@ -188,6 +188,8 @@ static inline void __wake(volatile void *addr, int cnt, int priv)
 #else
 #ifdef _REENTRANT
 	__builtin_wasm_memory_atomic_notify((int*)addr, cnt);
+#else
+        (void) addr;
 #endif
 #endif
 }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,6 +60,13 @@ add_library(libc_test_support STATIC
 )
 target_include_directories(libc_test_support PUBLIC "${LIBC_TEST}/src/common")
 add_wasilibc_flags(libc_test_support)
+# Disable some warnings in this third-party code
+target_compile_options(libc_test_support PRIVATE
+  -Wno-unused-variable
+  -Wno-unused-parameter
+  -Wno-unused-function
+  -Wno-sign-compare
+)
 
 # Adds a new test executable to build
 #
@@ -177,6 +184,13 @@ function(add_libc_test test_file)
 
   add_test_executable(${test_name} "${test_file}" ${ARGN})
   register_test(${test_name} ${test_name} ${ARGN})
+  # Disable some warnings in this third-party code
+  target_compile_options(${test_name} PRIVATE
+    -Wno-sign-compare
+    -Wno-missing-braces
+    -Wno-unused-variable
+    -Wno-unused-parameter
+  )
 endfunction()
 
 add_libc_test(functional/argv.c)
@@ -306,7 +320,11 @@ if (TARGET_TRIPLE MATCHES "-threads")
   add_wasilibc_test(busywait.c)
   add_wasilibc_test(pthread_cond_busywait.c)
   add_wasilibc_test(pthread_tsd_busywait.c)
+
+  # This test #include's a test whose source is not controlled here, so disable
+  # some extra warnings.
   add_wasilibc_test(pthread_mutex_busywait.c)
+  target_compile_options(pthread_mutex_busywait.wasm PRIVATE -Wno-unused-variable)
 endif()
 
 # ========= sockets-related tests ===============================

--- a/test/src/argv_two_args.c
+++ b/test/src/argv_two_args.c
@@ -14,7 +14,7 @@ int main(int argc, char **argv) {
 
   for (int i = 0; i < argc; i++) {
     TEST(argv[i][0] != 0, "argument should not be empty\n");
-    TEST(snprintf(buf, sizeof buf, "%s", argv[i]) < sizeof buf,
+    TEST(snprintf(buf, sizeof buf, "%s", argv[i]) < (ssize_t)sizeof buf,
          "argument is not a valid path\n");
   }
   return t_status;

--- a/test/src/busywait.c
+++ b/test/src/busywait.c
@@ -1,3 +1,5 @@
+#undef NDEBUG
+
 #include <assert.h>
 #include <errno.h>
 #include <pthread.h>

--- a/test/src/external_env.c
+++ b/test/src/external_env.c
@@ -5,7 +5,7 @@
 
 #define TEST(c, ...) ((c) || (t_error(#c " failed: " __VA_ARGS__), 0))
 
-int main(int argc, char **argv) {
+int main() {
   char *s = getenv("VAR1");
   TEST(strcmp(s, "foo") == 0);
   s = getenv("VAR2");

--- a/test/src/feof.c
+++ b/test/src/feof.c
@@ -27,7 +27,7 @@ static FILE *make_temp_file() {
 
 static FILE *writetemp(const char *data) {
   FILE *f = make_temp_file();
-  size_t n = strlen(data);
+  ssize_t n = strlen(data);
   if (!f)
     return 0;
   if (write(fileno(f), data, n) != n) {

--- a/test/src/fseek.c
+++ b/test/src/fseek.c
@@ -27,7 +27,7 @@ static FILE *make_temp_file() {
 
 static FILE *writetemp(const char *data) {
   FILE *f = make_temp_file();
-  size_t n = strlen(data);
+  ssize_t n = strlen(data);
   if (!f)
     return 0;
   if (write(fileno(f), data, n) != n) {

--- a/test/src/fts.c
+++ b/test/src/fts.c
@@ -157,7 +157,6 @@ void __expect_child_ftsent(FTSENT *p, const char *name, short level, int info,
 
 void test_fts_children(int base_options) {
   FTS *ftsp;
-  FTSENT *p;
 
   mkdir("t3", 0755);
   touch("t3/file1");
@@ -186,8 +185,8 @@ void test_fts_children(int base_options) {
 
 int main(void) {
   int base_options_set[] = {FTS_PHYSICAL, FTS_NOCHDIR};
-  for (int i = 0; i < sizeof(base_options_set) / sizeof(base_options_set[0]);
-       i++) {
+  for (unsigned i = 0;
+       i < sizeof(base_options_set) / sizeof(base_options_set[0]); i++) {
     test_fts_info(base_options_set[i]);
     test_symlink_fts_info(base_options_set[i]);
     test_fts_children(base_options_set[i]);

--- a/test/src/fwscanf.c
+++ b/test/src/fwscanf.c
@@ -29,7 +29,7 @@ static FILE *make_temp_file() {
 
 static FILE *writetemp(const char *data) {
   FILE *f = make_temp_file();
-  size_t n = strlen(data);
+  ssize_t n = strlen(data);
   if (!f)
     return 0;
   if (write(fileno(f), data, n) != n) {

--- a/test/src/poll-connect.c
+++ b/test/src/poll-connect.c
@@ -131,7 +131,7 @@ int main() {
     TEST(recv(client, received, sizeof(data), 0) == sizeof(data));
 
     // Assert that what was received matches what was sent.
-    for (int i = 0; i < sizeof(data); ++i) {
+    for (size_t i = 0; i < sizeof(data); ++i) {
       ASSERT(received[i] == data[i]);
     }
   }
@@ -156,7 +156,6 @@ int main() {
     }
 
     // Write until we hit backpressure
-    ssize_t write_total = 0;
     while (1) {
       if (t_status)
         exit(t_status);
@@ -166,8 +165,6 @@ int main() {
       if (count == -1) {
         TEST2(errno == EAGAIN || errno == EWOULDBLOCK || errno == EINPROGRESS);
         break;
-      } else {
-        write_total += count;
       }
     }
 
@@ -196,7 +193,7 @@ int main() {
         for (ssize_t i = 0; i < count; ++i) {
           ASSERT(received[i] == 42);
         }
-        if (read_total == data_len) {
+        if ((size_t)read_total == data_len) {
           break;
         }
       }

--- a/test/src/scandir.c
+++ b/test/src/scandir.c
@@ -29,7 +29,6 @@ int compare(const struct dirent **dirent1, const struct dirent **dirent2) {
 }
 
 int main(void) {
-  char tmp[] = "testsuite-XXXXXX";
   int fd;
   int flags = 0;
 

--- a/test/src/seekdir.c
+++ b/test/src/seekdir.c
@@ -46,9 +46,7 @@ int main(void) {
 
   DIR *dir = opendir("test");
   TEST(dir != NULL);
-  struct dirent *entry;
 
-  int is_end;
   while (1) {
     positions[count] = telldir(dir);
     if (readdir(dir) == NULL)

--- a/test/src/sockets-client-hangup-after-sending.c
+++ b/test/src/sockets-client-hangup-after-sending.c
@@ -46,7 +46,6 @@ void test_tcp_client() {
   // Connect from client
   char message[] = "There's gonna be a party when the wolf comes home";
   int len = strlen(message);
-  char client_buffer[BUFSIZE];
 
   int socket_fd = wait_for_server(&sockaddr_in);
 

--- a/test/src/sockets-client-hangup-while-receiving.c
+++ b/test/src/sockets-client-hangup-while-receiving.c
@@ -59,7 +59,7 @@ void test_tcp_client() {
                   sizeof(tv)) == 0);
 
   // Client reads from server
-  int32_t bytes_received = recv(socket_fd, client_buffer, len, 0);
+  recv(socket_fd, client_buffer, len, 0);
 
   // Shut down client
   close(socket_fd);

--- a/test/src/sockets-client-hangup-while-sending.c
+++ b/test/src/sockets-client-hangup-while-sending.c
@@ -46,7 +46,6 @@ void test_tcp_client() {
   // Connect from client
   char message[] = "There's gonna be a party when the wolf comes home";
   int len = strlen(message);
-  char client_buffer[BUFSIZE];
 
   int socket_fd = wait_for_server(&sockaddr_in);
 

--- a/test/src/sockets-multiple-server.c
+++ b/test/src/sockets-multiple-server.c
@@ -20,7 +20,7 @@
   } while (0)
 
 int BUFSIZE = 256;
-int EXPECTED_CONNECTIONS = 10;
+size_t EXPECTED_CONNECTIONS = 10;
 int TIMEOUT = 100;
 
 size_t respond_to_client(int client_fd) {
@@ -55,7 +55,7 @@ void run_tcp_server() {
   socklen_t client_len = sizeof(struct sockaddr_in);
   int client_socket_fd;
   struct sockaddr_in client_address;
-  int32_t bytes_read = 0, total_bytes_read = 0;
+  int32_t total_bytes_read = 0;
   TEST(listen(server_socket_fd, 1) != -1);
 
   // Server accepts connection
@@ -72,9 +72,8 @@ void run_tcp_server() {
 
   // Poll on the array of client file descriptors and respond to
   // any that are ready
-  size_t connections = 0;
   while (poll(client_fds, EXPECTED_CONNECTIONS, TIMEOUT) != 0) {
-    for (int i = 0; i < EXPECTED_CONNECTIONS; i++) {
+    for (size_t i = 0; i < EXPECTED_CONNECTIONS; i++) {
       if (client_fds[i].revents | POLLIN) {
         total_bytes_read += respond_to_client(client_fds[i].fd);
         // If fd is negative, revents will be set to 0 on the next call

--- a/test/src/sockets-nonblocking-multiple.c
+++ b/test/src/sockets-nonblocking-multiple.c
@@ -19,17 +19,13 @@
       t_error("%s failed (errno = %d)\n", #c, errno);                          \
   } while (0)
 
-// #define _DEBUG 1
+#define _DEBUG 0
 
-#ifdef _DEBUG
 #define DEBUG_PRINT(...)                                                       \
-  fprintf(stderr, __VA_ARGS__);                                                \
-  fflush(stdout)
-#else
-#define DEBUG_PRINT(...)                                                       \
-  do {                                                                         \
-  } while (0)
-#endif
+  if (_DEBUG) {                                                                \
+    fprintf(stderr, __VA_ARGS__);                                              \
+    fflush(stdout);                                                            \
+  }
 
 #define BUFSIZE 256
 size_t MAX_CONNECTIONS = 10;
@@ -79,11 +75,8 @@ void test_tcp_client() {
             sizeof(server_address)) != -1);
 
   // Listen on socket
-  char buffer[BUFSIZE];
   socklen_t client_len = sizeof(struct sockaddr_in);
-  int client_socket_fd = -1;
   struct sockaddr_in client_address;
-  int32_t bytes_read = 0, total_bytes_read = 0;
   TEST(listen(server_socket_fd, 1) != -1);
 
   // Prepare client sockets
@@ -125,13 +118,13 @@ void test_tcp_client() {
   poll_fd_server[0].fd = server_socket_fd;
   poll_fd_server[0].events = POLLRDNORM;
   poll_fd_server[0].revents = 0;
-  int next_client = 0;
+  size_t next_client = 0;
   bool failure = false;
 
   while (!done(client_outgoing, client_incoming) &&
          (next_client < MAX_CONNECTIONS * 2)) {
 
-    DEBUG_PRINT("============== next_client = %d ================\n",
+    DEBUG_PRINT("============== next_client = %zu ================\n",
                 next_client);
 
     // One client tries to connect
@@ -146,8 +139,8 @@ void test_tcp_client() {
         struct pollfd poll_fd = {.fd = client_sockets[next_client],
                                  .events = POLLWRNORM,
                                  .revents = 0};
-        int getsockopt_result = getsockopt(client_sockets[next_client],
-                                           SOL_SOCKET, SO_ERROR, &error, &len);
+        getsockopt(client_sockets[next_client], SOL_SOCKET, SO_ERROR, &error,
+                   &len);
         poll(&poll_fd, 1, 100);
         // Check if socket has become writable
         TEST(getsockopt(client_sockets[next_client], SOL_SOCKET, SO_ERROR,
@@ -159,7 +152,7 @@ void test_tcp_client() {
           poll_fd_client[next_client - 1].fd = client_sockets[next_client - 1];
           poll_fd_client[next_client - 1].events = POLLWRNORM;
           poll_fd_server[next_client - 1].revents = 0;
-          DEBUG_PRINT("Client [#%d] = %d connected\n", next_client - 1,
+          DEBUG_PRINT("Client [#%zu] = %d connected\n", next_client - 1,
                       client_sockets[next_client - 1]);
         }
       } else {
@@ -175,7 +168,7 @@ void test_tcp_client() {
     // Server polls for new connections and activity on existing connections,
     // simultaneously
     poll(poll_fd_server, next_server_socket + 1, 100);
-    int to_poll = next_server_socket + 1;
+    size_t to_poll = next_server_socket + 1;
     bool recv_failed = false;
     DEBUG_PRINT("Server looping through poll events errno = %s\n",
                 strerror(errno));
@@ -225,8 +218,8 @@ void test_tcp_client() {
 
     // All connected clients try to send
     bool send_failed = false;
-    for (int32_t i = 0; i < next_client; i++) {
-      DEBUG_PRINT("client_outgoing[%d] %s\n", i,
+    for (size_t i = 0; i < next_client; i++) {
+      DEBUG_PRINT("client_outgoing[%zu] %s\n", i,
                   client_outgoing[i].sent ? "sent" : "not sent");
       if (!client_outgoing[i].sent) {
         client_outgoing[i].sent = true;
@@ -264,13 +257,13 @@ void test_tcp_client() {
 
     // All connected clients try to receive
     if (next_client > 0) {
-      for (int32_t i = 0; i < next_client; i++)
+      for (size_t i = 0; i < next_client; i++)
         poll_fd_client[i].events = POLLRDNORM;
       poll(poll_fd_client, next_client, 100);
     }
     DEBUG_PRINT("Looping through poll events\n");
-    for (int32_t i = 0; i < next_client; i++) {
-      DEBUG_PRINT("poll_fd_client[%d].revents = %d\n", i,
+    for (size_t i = 0; i < next_client; i++) {
+      DEBUG_PRINT("poll_fd_client[%zu].revents = %d\n", i,
                   poll_fd_client[i].revents);
       if (poll_fd_client[i].revents & POLLRDNORM) {
         int bytes_received =

--- a/test/src/sockets-nonblocking-udp-multiple.c
+++ b/test/src/sockets-nonblocking-udp-multiple.c
@@ -32,7 +32,7 @@
 #endif
 
 #define BUFSIZE 256
-int MAX_CONNECTIONS = 10;
+size_t MAX_CONNECTIONS = 10;
 
 struct response {
   bool responded;
@@ -119,10 +119,9 @@ void test_udp_client() {
 
   struct pollfd server_pollfd = {
       .fd = server_socket_fd, .events = POLLRDNORM, .revents = 0};
-  struct pollfd server_client_pollfds[MAX_CONNECTIONS];
   size_t next_client = 0;
   size_t server_client_index = 0;
-  int32_t tries = 0;
+  size_t tries = 0;
   while (!done(client_outgoing, client_incoming) &&
          (tries < (MAX_CONNECTIONS * 2))) {
     DEBUG_PRINT("server polling for new messages\n");

--- a/test/src/sockets-server-handle-hangups.c
+++ b/test/src/sockets-server-handle-hangups.c
@@ -39,7 +39,7 @@ void run_tcp_server() {
   socklen_t client_len = sizeof(struct sockaddr_in);
   int client_socket_fd;
   struct sockaddr_in client_address;
-  int32_t bytes_read = 0, total_bytes_read = 0;
+  int32_t bytes_read = 0;
   TEST(listen(server_socket_fd, 1) != -1);
 
   // Server accepts connection
@@ -58,7 +58,6 @@ void run_tcp_server() {
   // Server waits for input and echoes message back to client
   // The server shuts down after the client closes the connection
   while ((bytes_read = recv(client_socket_fd, buffer, BUFSIZE, 0)) > 0) {
-    total_bytes_read += bytes_read;
     // Echo back the data received from the client
     send(client_socket_fd, buffer, bytes_read, 0);
   }

--- a/test/src/sockets-server-hangup-before-send.c
+++ b/test/src/sockets-server-hangup-before-send.c
@@ -35,11 +35,9 @@ void run_tcp_server() {
             sizeof(server_address)) != -1);
 
   // Listen on socket
-  char buffer[BUFSIZE];
   socklen_t client_len = sizeof(struct sockaddr_in);
   int client_socket_fd;
   struct sockaddr_in client_address;
-  int32_t bytes_read = 0, total_bytes_read = 0;
   TEST(listen(server_socket_fd, 1) != -1);
 
   // Server accepts connection

--- a/test/src/sockets-server-hangup-during-recv.c
+++ b/test/src/sockets-server-hangup-during-recv.c
@@ -39,7 +39,7 @@ void run_tcp_server() {
   socklen_t client_len = sizeof(struct sockaddr_in);
   int client_socket_fd;
   struct sockaddr_in client_address;
-  int32_t bytes_read = 0, total_bytes_read = 0;
+  int32_t bytes_read = 0;
   TEST(listen(server_socket_fd, 1) != -1);
 
   // Server accepts connection

--- a/test/src/sockets-server-hangup-during-send.c
+++ b/test/src/sockets-server-hangup-during-send.c
@@ -39,7 +39,7 @@ void run_tcp_server() {
   socklen_t client_len = sizeof(struct sockaddr_in);
   int client_socket_fd;
   struct sockaddr_in client_address;
-  int32_t bytes_read = 0, total_bytes_read = 0;
+  int32_t bytes_read = 0;
   TEST(listen(server_socket_fd, 1) != -1);
 
   // Server accepts connection

--- a/test/src/strptime.c
+++ b/test/src/strptime.c
@@ -39,20 +39,6 @@ static void checkStrptime(const char *s, const char *format,
   }
 }
 
-static void checkStrptimeTz(const char *s, int h, int m) {
-  long int expected = h * 3600 + m * 60;
-  struct tm tm = {};
-  const char *ret;
-
-  ret = strptime(s, "%z", &tm);
-  if (!ret || *ret != '\0') {
-    t_error("\"%%z\": failed to parse \"%s\"\n", s);
-  } else if (tm.tm_gmtoff != expected) {
-    t_error("\"%%z\": for \"%s\" expected tm_gmtoff %ld but got %ld\n", s,
-            tm.tm_gmtoff, expected);
-  }
-}
-
 static struct tm tm1 = {
     .tm_sec = 8,
     .tm_min = 57,

--- a/test/src/utime.c
+++ b/test/src/utime.c
@@ -30,6 +30,7 @@ static int doit_futimens(int fd, const struct timespec times[2]) {
 }
 
 static int doit_utimensat(int fd, const struct timespec times[2]) {
+  (void)fd;
   return utimensat(AT_FDCWD, "temp_file", times, 0);
 }
 


### PR DESCRIPTION
While wasi-libc is compiled with `-Wall -Wextra` it ended up disabling a lot of warnings as well to handle third-party code. This commit reorganizes things by continuing to compile everything with `-Wall -Wextra` but disabling lints is done exclusively for third-party code rather than for all code in wasi-libc. In practice this means that everything in `libc-bottom-half`, code written exclusively for this repository, now has more lints firing. This additionally applies to `test/src/*.c`. Much of this commit is handling these lints then and adjusting a few patterns in places where necessary.

This commit additionally disables compiling with `-Werror` by default. CI still enables this by default, but it means that new lints/warnings won't be breaking for anyone else other than this repository's own CI which should have pinned versions of Clang being used in various places.