### PR TITLE
wasip3: Perform a thread yield in `poll` with no timeout

### DIFF
--- a/libc-bottom-half/cloudlibc/src/libc/poll/poll.c
+++ b/libc-bottom-half/cloudlibc/src/libc/poll/poll.c
@@ -424,6 +424,14 @@ static int poll_impl(struct pollfd *fds, size_t nfds, int timeout) {
     wasip3_waitable_set_wait(state.set, &event);
   } else {
     wasip3_waitable_set_poll(state.set, &event);
+
+    // If nothing happened after this `poll`, then yield to the runtime to allow
+    // harvesting any events and avoid starvation if we're being called in a
+    // loop with a timeout of 0.
+    if (event.event == WASIP3_EVENT_NONE) {
+      wasip3_thread_yield();
+      wasip3_waitable_set_poll(state.set, &event);
+    }
   }
   while (event.event != WASIP3_EVENT_NONE) {
     // If this event is for the timeout subtask then that's handled directly here


### PR DESCRIPTION
This commit updates the `poll` implementation on wasip3 to insert a call to the canonical `thread.yield` function in the case that there's no timeout and nothing is ready yet. This explicitly provides the host an opportunity to deliver events and resolve any potential otherwise-deadlock if the guest is spinning waiting for events to happen with a timeout of 0.

This is related to bytecodealliance/wasmtime#13040 and is a partial guest-side solution for what's outlined there.