### PR TITLE
Add a missing `drop-readable` call

### DIFF
--- a/libc-bottom-half/sources/tcp.c
+++ b/libc-bottom-half/sources/tcp.c
@@ -174,6 +174,7 @@ static int tcp_read_eof(void *data) {
     __wasilibc_future_block_on(sockets_future_result_void_error_code_read(
                                    state->receive_result, &result),
                                state->receive_result);
+    sockets_future_result_void_error_code_drop_readable(state->receive_result);
     state->receive_result = 0;
     if (result.is_err)
       return __wasilibc_socket_error_to_errno(&result.val.err);

--- a/libc-bottom-half/sources/tcp.c
+++ b/libc-bottom-half/sources/tcp.c
@@ -216,6 +216,7 @@ static int tcp_write_eof(void *data) {
     __wasilibc_future_block_on(
         sockets_future_result_void_error_code_read(state->send_result, &result),
         state->send_result);
+    sockets_future_result_void_error_code_drop_readable(state->send_result);
     state->send_result = 0;
     if (result.is_err)
       return __wasilibc_socket_error_to_errno(&result.val.err);


### PR DESCRIPTION
I'm not sure how to add a test for this so the fix here is just in isolation.