### PR TITLE
Adjust state when starting an accept

### DIFF
--- a/libc-bottom-half/sources/tcp.c
+++ b/libc-bottom-half/sources/tcp.c
@@ -343,8 +343,8 @@ static bool wasip3_tcp_accept_start(tcp_socket_state_listening_t *state) {
          !(state->flags & TCP_LISTENING_ACCEPT_READY)) {
     wasip3_waitable_status_t status = sockets_stream_own_tcp_socket_read(
         state->stream, &state->accept_result, 1);
+    state->flags |= TCP_LISTENING_ACCEPTING;
     if (status == WASIP3_WAITABLE_STATUS_BLOCKED) {
-      state->flags |= TCP_LISTENING_ACCEPTING;
       return true;
     }
     wasip3_tcp_accept_finish(state, status);

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -416,6 +416,7 @@ if (NOT (WASI STREQUAL "p1"))
   add_wasilibc_test(sockets-nonblocking.c NETWORK)
   add_wasilibc_test(sockets-nonblocking-udp-no-connection.c NETWORK)
   add_wasilibc_test(sockets-eof-delayed.c NETWORK)
+  add_wasilibc_test(sockets-nonblocking-accept-multiple.c NETWORK)
 
   # Define executables for server/client tests, and they're paired together in
   # various combinations below for various tests.

--- a/test/src/sockets-nonblocking-accept-multiple.c
+++ b/test/src/sockets-nonblocking-accept-multiple.c
@@ -1,0 +1,87 @@
+#include "test.h"
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <poll.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#define TEST(c)                                                                \
+  do {                                                                         \
+    errno = 0;                                                                 \
+    if (!(c))                                                                  \
+      t_error("%s failed (errno = %d)\n", #c, errno);                          \
+  } while (0)
+
+#define N 10
+
+int main() {
+  char buf[10];
+  int listener_fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+
+  // Setup a listener bound to port 0 to have the OS assign us one.
+  struct sockaddr_in server_address;
+  socklen_t server_address_len = sizeof(server_address);
+  server_address.sin_family = AF_INET;
+  server_address.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+  server_address.sin_port = 0;
+  TEST(bind(listener_fd, (struct sockaddr *)&server_address,
+            sizeof(server_address)) != -1);
+  TEST(getsockname(listener_fd, (struct sockaddr *)&server_address,
+                   &server_address_len) != -1);
+  TEST(listen(listener_fd, N) != -1);
+
+  struct pollfd clients[N];
+  int remaining = N;
+
+  // Connect N clients, then wait for them all to reach the writable state
+  // meaning that they're more-or-less
+  // connected.
+  for (int i = 0; i < N; i++) {
+    int client_fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
+    TEST(client_fd != -1);
+    int rc;
+    TEST((rc =connect(client_fd, (struct sockaddr *)&server_address,
+                 server_address_len)) != -1 ||
+         errno == EINPROGRESS);
+    clients[i].fd = client_fd;
+    if (rc == -1) {
+      clients[i].events = POLLWRNORM;
+    } else {
+      remaining--;
+      clients[i].events = 0;
+    }
+  }
+
+  while (remaining > 0) {
+    TEST(poll(clients, N, -1) > 0);
+
+    for (int i = 0; i < N; i++) {
+      if (clients[i].revents & POLLWRNORM) {
+        clients[i].events = 0;
+        remaining--;
+      }
+    }
+  }
+
+  // Now accept everything quickly and close it all.
+  for (int i = 0; i < N; i++) {
+    struct pollfd listener;
+    listener.fd = listener_fd;
+    listener.events = POLLRDNORM;
+    TEST(poll(&listener, 1, -1) == 1);
+    int server_fd;
+    TEST((server_fd = accept(listener_fd, NULL, NULL)) != -1);
+    TEST(close(server_fd) != -1);
+  }
+
+  for (int i = 0; i < N; i++)
+    TEST(close(clients[i].fd) != -1);
+
+  return t_status;
+}

--- a/test/src/sockets-nonblocking-accept-multiple.c
+++ b/test/src/sockets-nonblocking-accept-multiple.c
@@ -45,8 +45,8 @@ int main() {
     int client_fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
     TEST(client_fd != -1);
     int rc;
-    TEST((rc =connect(client_fd, (struct sockaddr *)&server_address,
-                 server_address_len)) != -1 ||
+    TEST((rc = connect(client_fd, (struct sockaddr *)&server_address,
+                       server_address_len)) != -1 ||
          errno == EINPROGRESS);
     clients[i].fd = client_fd;
     if (rc == -1) {

--- a/test/src/sockets-nonblocking-accept-multiple.c
+++ b/test/src/sockets-nonblocking-accept-multiple.c
@@ -21,7 +21,6 @@
 #define N 10
 
 int main() {
-  char buf[10];
   int listener_fd = socket(AF_INET, SOCK_STREAM | SOCK_NONBLOCK, 0);
 
   // Setup a listener bound to port 0 to have the OS assign us one.


### PR DESCRIPTION
Set the flags that an accept is in-progress regardless of whether it completes or not, resolving an assertion failure. This is not currently possible to test with Wasmtime, but with bytecodealliance/wasmtime#13158 and the test included here the assertion is hit reliably.