### PR TITLE
wasip3: Fix zero-length reads/writes on streams

### DIFF
--- a/libc-bottom-half/sources/file_utils.c
+++ b/libc-bottom-half/sources/file_utils.c
@@ -362,6 +362,11 @@ ssize_t __wasilibc_write(wasi_write_t *write, const void *buffer,
   assert((state->flags & WASIP3_IO_INPROGRESS) == 0);
   assert((state->flags & WASIP3_IO_ZERO_INPROGRESS) == 0);
 
+  // Follow posix semantics for zero-length writes which appear to return 0
+  // without actually doing any I/O.
+  if (length == 0)
+    return 0;
+
   // If this stream is complete, then delegate to EOF.
   if (state->flags & WASIP3_IO_DONE)
     return write->eof(write->eof_data);
@@ -586,6 +591,11 @@ ssize_t __wasilibc_read(wasi_read_t *read, void *buffer, size_t length) {
   // that out here.
   if (state->buf)
     return wasip3_read_complete_internally(state, buffer, length);
+
+  // Implement posix-like semantics where a `read` of 0 bytes doesn't do
+  // anything and just returns 0.
+  if (length == 0)
+    return 0;
 
   // If this stream has finished, then delegate to EOF.
   if (state->flags & WASIP3_IO_DONE)

--- a/test/src/sockets-client.c
+++ b/test/src/sockets-client.c
@@ -48,7 +48,10 @@ void test_tcp_client(int server_port) {
   TEST(bytes_received == len);
 
   // Message received should be the same as message sent
-  TEST(strcmp(message, client_buffer) == 0);
+  TEST(memcmp(message, client_buffer, len) == 0);
+
+  TEST(read(socket_fd, NULL, 0) == 0);
+  TEST(write(socket_fd, NULL, 0) == 0);
 
   // Shut down client
   close(socket_fd);

--- a/test/src/sockets-nonblocking.c
+++ b/test/src/sockets-nonblocking.c
@@ -138,6 +138,11 @@ void test_tcp_client() {
     TEST(poll(&poll_fd, 1, -1) != -1);
   }
 
+  TEST(read(client_socket_fd, NULL, 0) == 0);
+  TEST(write(client_socket_fd, NULL, 0) == 0);
+  TEST(read(socket_fd, NULL, 0) == 0);
+  TEST(write(socket_fd, NULL, 0) == 0);
+
   // Message received should be the same as message sent
   TEST(strcmp(message, client_buffer) == 0);
 


### PR DESCRIPTION
Previously this trapped internally due to state not getting lined up right and/or returned the wrong result. Now this tries to follow posix and not actually do any I/O for zero-length reads/writes.