### PR TITLE
wasip3: Improve/fix handling of buffered reads

### DIFF
--- a/libc-bottom-half/sources/file_utils.c
+++ b/libc-bottom-half/sources/file_utils.c
@@ -238,6 +238,7 @@ static int wasip3_read_start_nonzero(wasip3_io_state_t *state, size_t length) {
   assert(!(state->flags & WASIP3_IO_ZERO_INPROGRESS));
   assert(!(state->flags & WASIP3_IO_DONE));
   assert(state->buf == NULL);
+  assert(length);
   state->buf = malloc(length);
   if (!state->buf) {
     errno = ENOMEM;
@@ -252,7 +253,7 @@ static int wasip3_read_start_nonzero(wasip3_io_state_t *state, size_t length) {
     errno = EWOULDBLOCK;
     return -1;
   }
-
+  state->buf_end = wasip3_io_update_code(state, status);
   return 0;
 }
 


### PR DESCRIPTION
This updates the code path that performs a buffered read for a stream when zero-length reads/writes are determined to not signal readiness correctly. Specifically a defensive assertion that this is a nonzero-length read is added and additionally in the case that I/O completes immediately the return code is handled appropriately. Unfortunately I don't know of a way to test this as it's not testable from Wasmtime today and the file streams implementation in Wasmtime ends up sort of accidentally respecting the zero-length protocol (sort of). Thus, for now, this is just a code change until more comprehensive testing such as #766 is implemented.