### PR TITLE
Disable support for nonblocking file I/O

### DIFF
--- a/libc-bottom-half/sources/file.c
+++ b/libc-bottom-half/sources/file.c
@@ -123,7 +123,7 @@ static int file_get_read_stream(void *data, wasi_read_t *read) {
 #endif
   read->offset = &file->offset;
   read->timeout = 0;
-  read->blocking = (file->oflag & O_NONBLOCK) == 0;
+  read->blocking = true;
   return 0;
 }
 
@@ -193,7 +193,7 @@ static int file_get_write_stream(void *data, wasi_write_t *write) {
 #endif
   write->offset = &file->offset;
   write->timeout = 0;
-  write->blocking = (file->oflag & O_NONBLOCK) == 0;
+  write->blocking = true;
   return 0;
 }
 


### PR DESCRIPTION
Concerns brought up in #788 rightfully point out that this doesn't work on other platforms and it's been such a core assumption for so long we run more of a risk of breaking code by supporting it than we do continuing to not support it. This means that some recent changes no longer have test coverage, but that seems best addressed by #766 so it's deferred to that.